### PR TITLE
cargo: murmur3 target specific commit

### DIFF
--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -14,7 +14,7 @@ ares_macros = { path = "../ares_macros" }
 bitvec = "1.0.0"
 either = "1.6.1"
 libc = "0.2.126"
-murmur3 = { git = "https://github.com/tloncorp/murmur3", branch = "eamsden/non_copying" }
+murmur3 = { git = "https://github.com/tloncorp/murmur3", rev = "7878a0f" }
 memmap = "0.7.0"
 intmap = "1.1.0"
 num-traits = "0.2"

--- a/rust/ares/src/mug.rs
+++ b/rust/ares/src/mug.rs
@@ -2,15 +2,15 @@ use crate::assert_acyclic;
 use crate::mem::*;
 use crate::noun::{Allocated, Atom, DirectAtom, Noun};
 use either::Either::*;
-use murmur3::murmur3_32_nocopy;
+use murmur3::murmur3_32_of_slice;
 
 crate::gdb!();
 
 // Murmur3 hash an atom with a given padded length
 fn muk_u32(syd: u32, len: usize, key: Atom) -> u32 {
     match key.as_either() {
-        Left(direct) => murmur3_32_nocopy(&direct.data().to_le_bytes()[0..len], syd),
-        Right(indirect) => murmur3_32_nocopy(&indirect.as_bytes()[..len], syd),
+        Left(direct) => murmur3_32_of_slice(&direct.data().to_le_bytes()[0..len], syd),
+        Right(indirect) => murmur3_32_of_slice(&indirect.as_bytes()[..len], syd),
     }
 }
 


### PR DESCRIPTION
the name of murmur3_32_nocopy was changed to murmur3_32_of_slices but to avoid breaking things we're just going to target the last commit where its called murmur3_32_nocopy