### PR TITLE
copy() memory issue fix

### DIFF
--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -278,7 +278,8 @@ impl NockStack {
     }
 
     unsafe fn indirect_alloc_in_previous_frame_east(&mut self, words: usize) -> *mut u64 {
-        *(self.prev_alloc_pointer_pointer()) = *(self.prev_alloc_pointer_pointer()).sub(words + 2);
+        *(self.prev_alloc_pointer_pointer()) =
+            (*(self.prev_alloc_pointer_pointer())).sub(words + 2);
         *self.prev_alloc_pointer_pointer() as *mut u64
     }
 


### PR DESCRIPTION
Addresses #73 

I didn't realize this extra set of parentheses was doing any work tbh. Guess I need to review precedence order with the pointer interface.