### PR TITLE
main: make assert_no_alloc actually assert

### DIFF
--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -83,6 +83,17 @@ pub fn interpret(
         *(stack.local_noun_pointer(0)) = work_to_noun(Done);
     }
     push_formula(stack, formula);
+    // DO NOT REMOVE THIS ASSERTION
+    //
+    // If you need to allocate for debugging, wrap the debugging code in
+    //
+    // ```
+    // permit_alloc(|| {
+    //   your.code.goes.here()
+    // })
+    // ```
+    //
+    // (See https://docs.rs/assert_no_alloc/latest/assert_no_alloc/#advanced-use)
     assert_no_alloc(|| unsafe {
         loop {
             match noun_to_work(*(stack.local_noun_pointer(0))) {

--- a/rust/ares/src/lib.rs
+++ b/rust/ares/src/lib.rs
@@ -36,6 +36,18 @@ macro_rules! gdb {
     };
 }
 
+// Use the allocator from assert_no_alloc.
+//
+// DO NOT COMMENT THIS OUT
+//
+// if you need to allow allocations somewhere for debugging, wrap your debug code in
+// ```
+// permit_alloc( || {
+//   your.code.goes.here()
+// })
+// ```
+//
+// (see https://docs.rs/assert_no_alloc/latest/assert_no_alloc/#advanced-use)
 #[cfg(debug_assertions)]
 #[global_allocator]
 static A: assert_no_alloc::AllocDisabler = assert_no_alloc::AllocDisabler;

--- a/rust/ares/src/lib.rs
+++ b/rust/ares/src/lib.rs
@@ -36,9 +36,9 @@ macro_rules! gdb {
     };
 }
 
-// #[cfg(debug_assertions)]
-// #[global_allocator]
-// static A: assert_no_alloc::AllocDisabler = assert_no_alloc::AllocDisabler;
+#[cfg(debug_assertions)]
+#[global_allocator]
+static A: assert_no_alloc::AllocDisabler = assert_no_alloc::AllocDisabler;
 
 pub(crate) use gdb;
 

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -13,6 +13,12 @@ use std::mem;
 use std::ptr::copy_nonoverlapping;
 use std::ptr::write_bytes;
 
+use assert_no_alloc::*;
+
+#[cfg(debug_assertions)] // required when disable_release is set (default)
+#[global_allocator]
+static A: AllocDisabler = AllocDisabler;
+
 fn main() -> io::Result<()> {
     let filename = env::args().nth(1).expect("Must provide input filename");
 

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -13,12 +13,6 @@ use std::mem;
 use std::ptr::copy_nonoverlapping;
 use std::ptr::write_bytes;
 
-use assert_no_alloc::*;
-
-#[cfg(debug_assertions)] // required when disable_release is set (default)
-#[global_allocator]
-static A: AllocDisabler = AllocDisabler;
-
 fn main() -> io::Result<()> {
     let filename = env::args().nth(1).expect("Must provide input filename");
 


### PR DESCRIPTION
Can be tested with the patch:

```patch
diff --git a/rust/ares/src/jets/math.rs b/rust/ares/src/jets/math.rs
index 9993cb0..2882291 100644
--- a/rust/ares/src/jets/math.rs
+++ b/rust/ares/src/jets/math.rs
@@ -67,6 +67,16 @@ pub fn jet_add(stack: &mut NockStack, subject: Noun) -> Result<Noun, JetErr> {
     let a = raw_slot(arg, 2).as_atom()?;
     let b = raw_slot(arg, 3).as_atom()?;
 
+    eprintln!("AAAAAHHHH I'M ALLOOOOOOCATING");
+
+    let mut v : Vec<u64> = Vec::with_capacity(0);
+
+    v.push(1);
+    v.push(2);
+    v.push(3);
+
+    eprintln!("ALLOOOOOOCATED. Element 3: {}", v[2]);
+
     if let (Ok(a), Ok(b)) = (a.as_direct(), b.as_direct()) {
         Ok(Atom::new(stack, a.data() + b.data()).as_noun())
     } else {
```