### PR TITLE
ares: make ibig dep a relative path so importing as a crate works properly

### DIFF
--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[patch.crates-io]
-ibig = { path = "../ibig-rs" }
+# [patch.crates-io]
+# ibig = { path = "../ibig-rs" }
 
 [dependencies]
 ares_macros = { path = "../ares_macros" }
@@ -21,7 +21,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 criterion = "0.4"
 static_assertions = "1.1.0"
-ibig = "0.3.6"
+ibig = { path = "../ibig-rs" }
 assert_no_alloc = "1.1.2"
 
 [build-dependencies]


### PR DESCRIPTION
Using patch.crates-io does not work because it only applies to the local crate development and not as a setting for consumers of the package

Thanks to @drbeefsupreme for the original fix