### PR TITLE
mem: assert stack_is_empty() when it should be

### DIFF
--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -351,6 +351,7 @@ impl NockStack {
 
     unsafe fn copy(&mut self, noun: &mut Noun) {
         self.pre_copy();
+        assert!(self.stack_is_empty());
         let noun_ptr = noun as *mut Noun;
         // Add two slots to the lightweight stack
         // Set the first new slot to the noun to be copied
@@ -447,6 +448,7 @@ impl NockStack {
                 && (*(self.prev_stack_pointer_pointer())).is_null()
                 && (*(self.prev_frame_pointer_pointer())).is_null()
         );
+        assert!(self.stack_is_empty());
         let noun_ptr = noun as *mut Noun;
         *(self.push::<Noun>()) = *noun;
         *(self.push::<*mut Noun>()) = noun_ptr;


### PR DESCRIPTION
if these functions are callled with a non-empty lightweight stack, they will try to pop things that they shouldn't.

all other stack_is_empty() callsites happen in a fresh stack frame, so we already know the lightweight stack will be empty.

This would have made detecting the problem that #84 resolves take a few minutes instead of a few hours.