### PR TITLE
implement as_bytes() on Atom

### DIFF
--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -192,10 +192,6 @@ impl DirectAtom {
         &bytes[..]
     }
 
-    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-        let bytes: &mut [u8; 8] = unsafe { std::mem::transmute(self.0) };
-        &mut bytes[..]
-    }
 }
 
 impl fmt::Display for DirectAtom {
@@ -401,11 +397,6 @@ impl IndirectAtom {
     pub fn as_bytes(&self) -> &[u8] {
         unsafe { from_raw_parts(self.data_pointer() as *const u8, self.size() << 3) }
     }
-
-    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-        unsafe { from_raw_parts_mut(self.data_pointer_mut() as *mut u8, self.size() << 3) }
-    }
-
 
     /** BitSlice view on an indirect atom, with lifetime tied to reference to indirect atom. */
     pub fn as_bitslice(&self) -> &BitSlice<u64, Lsb0> {
@@ -734,13 +725,6 @@ impl Atom {
         }
     }
 
-    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-        if self.is_direct() {
-            unsafe { self.direct.as_bytes_mut() }
-        } else {
-            unsafe { self.indirect.as_bytes_mut() }
-        }
-    }
 }
 
 impl fmt::Display for Atom {

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -186,6 +186,16 @@ impl DirectAtom {
     pub fn as_bitslice_mut(&mut self) -> &mut BitSlice<u64, Lsb0> {
         BitSlice::from_element_mut(&mut self.0)
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        let bytes: &[u8; 8] = unsafe { std::mem::transmute(self.0) };
+        &bytes[..]
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        let bytes: &mut [u8; 8] = unsafe { std::mem::transmute(self.0) };
+        &mut bytes[..]
+    }
 }
 
 impl fmt::Display for DirectAtom {
@@ -391,6 +401,11 @@ impl IndirectAtom {
     pub fn as_bytes(&self) -> &[u8] {
         unsafe { from_raw_parts(self.data_pointer() as *const u8, self.size() << 3) }
     }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        unsafe { from_raw_parts_mut(self.data_pointer_mut() as *mut u8, self.size() << 3) }
+    }
+
 
     /** BitSlice view on an indirect atom, with lifetime tied to reference to indirect atom. */
     pub fn as_bitslice(&self) -> &BitSlice<u64, Lsb0> {
@@ -709,6 +724,22 @@ impl Atom {
 
     pub fn as_noun(self) -> Noun {
         Noun { atom: self }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        if self.is_direct() {
+            unsafe { self.direct.as_bytes() }
+        } else {
+            unsafe { self.indirect.as_bytes() }
+        }
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        if self.is_direct() {
+            unsafe { self.direct.as_bytes_mut() }
+        } else {
+            unsafe { self.indirect.as_bytes_mut() }
+        }
     }
 }
 

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -191,7 +191,6 @@ impl DirectAtom {
         let bytes: &[u8; 8] = unsafe { std::mem::transmute(self.0) };
         &bytes[..]
     }
-
 }
 
 impl fmt::Display for DirectAtom {
@@ -724,7 +723,6 @@ impl Atom {
             unsafe { self.indirect.as_bytes() }
         }
     }
-
 }
 
 impl fmt::Display for Atom {


### PR DESCRIPTION
This implements as_bytes() on Atom so you can handle direct and indirect atoms the same. For both it returns a reference to the underlying data as &[u8].