### PR TITLE
Fix loading from snapshot

### DIFF
--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -14,6 +14,11 @@ use std::ptr::copy_nonoverlapping;
 use std::ptr::write_bytes;
 
 fn main() -> io::Result<()> {
+    // eprintln!("serf: pid {}", std::process::id());
+    // if unsafe { libc::kill(std::process::id() as i32, libc::SIGSTOP) } != 0 {
+    //     panic!("Could not stop ourselves.");
+    // };
+
     let filename = env::args().nth(1).expect("Must provide input filename");
 
     if filename == "see gdb! definition in lib.rs about this" {

--- a/rust/ares/src/snapshot/double_jam.rs
+++ b/rust/ares/src/snapshot/double_jam.rs
@@ -78,7 +78,7 @@ impl DoubleJam {
                 | ((*in_ptr.add(1) as u32) << 8)
                 | ((*in_ptr.add(2) as u32) << 16)
                 | ((*in_ptr.add(3) as u32) << 24);
-            write_bytes(dest.add(word_len as usize - 1), 0, 8);
+            write_bytes(dest.add(word_len as usize - 1), 0, 1);
             copy_nonoverlapping(in_ptr.add(8), dest as *mut u8, in_len as usize);
             mem::drop(in_map);
             state.normalize(); // know it's not direct because first word is event number


### PR DESCRIPTION
`write_bytes` takes a number of word-sized entries, not a number of bytes.