### PR TITLE
mem: add reset() for NockStack

### DIFF
--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -88,6 +88,19 @@ impl NockStack {
         }
     }
 
+    /** Resets the NockStack. */
+    pub fn reset(&mut self, top_slots: usize) {
+        self.frame_pointer = unsafe { self.start.add(RESERVED + top_slots) } as *mut u64;
+        self.stack_pointer = self.frame_pointer;
+        self.alloc_pointer = unsafe { self.start.add(self.size) } as *mut u64;
+        self.pc = false;
+        unsafe {
+            *self.frame_pointer.sub(FRAME + 1) = ptr::null::<u64>() as u64; // "frame pointer" from "previous" frame
+            *self.frame_pointer.sub(STACK + 1) = ptr::null::<u64>() as u64; // "stack pointer" from "previous" frame
+            *self.frame_pointer.sub(ALLOC + 1) = ptr::null::<u64>() as u64; // "alloc pointer" from "previous" frame
+        };
+    }
+
     /** Current frame pointer of this NockStack */
     pub fn get_frame_pointer(&self) -> *const u64 {
         self.frame_pointer


### PR DESCRIPTION
Resets the NockStack. We'll need this for the PMA eventually, but Zorp also needs this right now.