### PR TITLE
Event-based profiling

### DIFF
--- a/rust/ares/Cargo.lock
+++ b/rust/ares/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "either",
  "ibig",
  "intmap",
+ "json",
  "lazy_static",
  "libc",
  "memmap",
@@ -321,6 +322,12 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -20,6 +20,7 @@ criterion = "0.4"
 either = "1.9.0"
 ibig = { path = "../ibig-rs" }
 intmap = "1.1.0"
+json = "0.12.4"
 lazy_static = "1.4.0"
 libc = "0.2.126"
 memmap = "0.7.0"

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -2,27 +2,22 @@ use crate::assert_acyclic;
 use crate::assert_no_forwarding_pointers;
 use crate::assert_no_junior_pointers;
 use crate::hamt::Hamt;
-use crate::jets::bits::util::rap;
 use crate::jets::cold;
 use crate::jets::cold::Cold;
-use crate::jets::form::util::scow;
 use crate::jets::hot::Hot;
 use crate::jets::warm::Warm;
 use crate::jets::JetErr;
 use crate::mem::unifying_equality;
 use crate::mem::NockStack;
-use crate::mug::met3_usize;
 use crate::newt::Newt;
 use crate::noun;
-use crate::noun::{Atom, Cell, DirectAtom, IndirectAtom, Noun, Slots, D, T};
+use crate::noun::{Atom, Cell, IndirectAtom, Noun, Slots, D, T};
 use crate::serf::TERMINATOR;
+use crate::trace::{write_nock_trace, TraceInfo, TraceStack};
 use ares_macros::tas;
 use assert_no_alloc::assert_no_alloc;
 use bitvec::prelude::{BitSlice, Lsb0};
 use either::Either::*;
-use json::object;
-use std::fs::File;
-use std::io::Write;
 use std::result;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -273,18 +268,6 @@ pub struct Context {
     pub trace_info: Option<TraceInfo>,
 }
 
-pub struct TraceInfo {
-    pub file: File,
-    pub pid: u32,
-    pub process_start: Instant,
-}
-
-pub struct TraceStack {
-    pub start: Instant,
-    pub path: Noun,
-    pub next: *const TraceStack,
-}
-
 #[derive(Clone, Copy, Debug)]
 pub enum Error {
     ScryBlocked(Noun),      // path
@@ -375,57 +358,10 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                     debug_assertions(stack, subject);
                     debug_assertions(stack, res);
 
-                    // Write fast-hinted traces to file
+                    // Write fast-hinted traces to trace file
                     if let Some(ref mut info) = &mut context.trace_info {
-                        let mut trace_stack =
-                            *(stack.local_noun_pointer(1) as *const *const TraceStack);
-                        let now = Instant::now();
-                        assert_no_alloc::permit_alloc(|| {
-                            while !trace_stack.is_null() {
-                                let ts = (*trace_stack)
-                                    .start
-                                    .saturating_duration_since(info.process_start)
-                                    .as_micros() as f64;
-                                let dur = now
-                                    .saturating_duration_since((*trace_stack).start)
-                                    .as_micros() as f64;
-
-                                // Don't write out traces less than 33us
-                                // (same threshhold used in vere)
-                                if dur < 33.0 {
-                                    trace_stack = (*trace_stack).next;
-                                    continue;
-                                }
-
-                                let pc = path_to_cord(stack, (*trace_stack).path);
-                                let pclen = met3_usize(pc);
-                                let pc_str = &pc.as_bytes()[0..pclen];
-
-                                let obj = object! {
-                                    cat: "nock",
-                                    name: pc_str,
-                                    ph: "X",
-                                    pid: info.pid,
-                                    tid: 2,
-                                    ts: ts,
-                                    dur: dur,
-                                };
-                                if let Err(e) = obj.write(&mut info.file) {
-                                    eprintln!("\rError writing trace to file: {:?}", e);
-                                    break;
-                                };
-                                //  XX: success above but failure here permanently malforms the trace file
-                                if let Err(e) = info.file.write(",\n".as_bytes()) {
-                                    eprintln!("\rError writing trace to file: {:?}", e);
-                                    break;
-                                };
-
-                                trace_stack = (*trace_stack).next;
-                            }
-                        });
-                        if let Err(e) = info.file.sync_data() {
-                            eprintln!("\rError syncing trace file: {:?}", e);
-                        };
+                        let trace_stack = *(stack.local_noun_pointer(1) as *mut *const TraceStack);
+                        write_nock_trace(stack, info, trace_stack);
                     }
 
                     stack.preserve(&mut context.cache);
@@ -703,17 +639,7 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                                     // jetted code.
                                     if context.trace_info.is_some() {
                                         if let Some(path) = context.cold.matches(stack, &mut res) {
-                                            // Push onto the tracing stack
-                                            let trace_stack = *(stack.local_noun_pointer(1)
-                                                as *const *const TraceStack);
-                                            let new_trace_entry = stack.struct_alloc(1);
-                                            *new_trace_entry = TraceStack {
-                                                path,
-                                                start: Instant::now(),
-                                                next: trace_stack,
-                                            };
-                                            *(stack.local_noun_pointer(1)
-                                                as *mut *const TraceStack) = new_trace_entry;
+                                            append_trace(stack, path);
                                         };
                                     };
 
@@ -738,17 +664,7 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                                     // jetted code.
                                     if context.trace_info.is_some() {
                                         if let Some(path) = context.cold.matches(stack, &mut res) {
-                                            // Push onto the tracing stack
-                                            let trace_stack = *(stack.local_noun_pointer(1)
-                                                as *const *const TraceStack);
-                                            let new_trace_entry = stack.struct_alloc(1);
-                                            *new_trace_entry = TraceStack {
-                                                path,
-                                                start: Instant::now(),
-                                                next: trace_stack,
-                                            };
-                                            *(stack.local_noun_pointer(1)
-                                                as *mut *const TraceStack) = new_trace_entry;
+                                            append_trace(stack, path);
                                         };
                                     };
                                 }
@@ -1183,7 +1099,7 @@ fn push_formula(stack: &mut NockStack, formula: Noun, tail: bool) -> result::Res
     Ok(())
 }
 
-pub fn exit(context: &mut Context, virtual_frame: *const u64, error: Error) -> Error {
+fn exit(context: &mut Context, virtual_frame: *const u64, error: Error) -> Error {
     unsafe {
         let stack = &mut context.stack;
 
@@ -1313,77 +1229,18 @@ pub fn inc(stack: &mut NockStack, atom: Atom) -> Atom {
     }
 }
 
-//  XX: Need Rust string interpolation helper that doesn't allocate
-fn path_to_cord(stack: &mut NockStack, path: Noun) -> Atom {
-    let mut cursor = path;
-    let mut length = 0usize;
-
-    // count how much size we need
-    while let Ok(c) = cursor.as_cell() {
-        unsafe {
-            match c.head().as_either_atom_cell() {
-                Left(a) => {
-                    length += 1;
-                    length += met3_usize(a);
-                }
-                Right(ch) => {
-                    if let Ok(nm) = ch.head().as_atom() {
-                        if let Ok(kv) = ch.tail().as_atom() {
-                            let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv)
-                                .expect("scow should succeed in path_to_cord");
-                            let kvc =
-                                rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
-                            length += 1;
-                            length += met3_usize(nm);
-                            length += met3_usize(kvc);
-                        }
-                    }
-                }
-            }
-        }
-        cursor = c.tail();
+/// Push onto the tracing stack
+fn append_trace(stack: &mut NockStack, path: Noun) {
+    unsafe {
+        let trace_stack = *(stack.local_noun_pointer(1) as *const *const TraceStack);
+        let new_trace_entry = stack.struct_alloc(1);
+        *new_trace_entry = TraceStack {
+            path,
+            start: Instant::now(),
+            next: trace_stack,
+        };
+        *(stack.local_noun_pointer(1) as *mut *const TraceStack) = new_trace_entry;
     }
-
-    // reset cursor, then actually write the path
-    cursor = path;
-    let mut idx = 0;
-    let (mut deres, buffer) = unsafe { IndirectAtom::new_raw_mut_bytes(stack, length) };
-    let slash = (b"/")[0];
-
-    while let Ok(c) = cursor.as_cell() {
-        unsafe {
-            match c.head().as_either_atom_cell() {
-                Left(a) => {
-                    buffer[idx] = slash;
-                    idx += 1;
-                    let bytelen = met3_usize(a);
-                    buffer[idx..idx + bytelen].copy_from_slice(&a.as_bytes()[0..bytelen]);
-                    idx += bytelen;
-                }
-                Right(ch) => {
-                    if let Ok(nm) = ch.head().as_atom() {
-                        if let Ok(kv) = ch.tail().as_atom() {
-                            let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv)
-                                .expect("scow should succeed in path_to_cord");
-                            let kvc =
-                                rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
-                            buffer[idx] = slash;
-                            idx += 1;
-                            let nmlen = met3_usize(nm);
-                            buffer[idx..idx + nmlen].copy_from_slice(&nm.as_bytes()[0..nmlen]);
-                            idx += nmlen;
-                            let kvclen = met3_usize(kvc);
-                            buffer[idx..idx + kvclen].copy_from_slice(&kvc.as_bytes()[0..kvclen]);
-                            idx += kvclen;
-                        }
-                    }
-                }
-            }
-        }
-        cursor = c.tail();
-    }
-
-    unsafe { deres.normalize_as_atom() }
 }
 
 mod hint {

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -361,7 +361,12 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                     // Write fast-hinted traces to trace file
                     if let Some(ref mut info) = &mut context.trace_info {
                         let trace_stack = *(stack.local_noun_pointer(1) as *mut *const TraceStack);
-                        write_nock_trace(stack, info, trace_stack);
+                        // Abort writing to trace file if we encountered an error. This should
+                        // result in a well-formed partial trace file.
+                        if let Err(e) = write_nock_trace(stack, info, trace_stack) {
+                            eprintln!("\rError writing trace to file: {:?}", e);
+                            context.trace_info = None;
+                        }
                     }
 
                     stack.preserve(&mut context.cache);

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -2,13 +2,13 @@ use crate::assert_acyclic;
 use crate::assert_no_forwarding_pointers;
 use crate::assert_no_junior_pointers;
 use crate::hamt::Hamt;
+use crate::jets::bits::util::rap;
 use crate::jets::cold;
 use crate::jets::cold::Cold;
+use crate::jets::form::util::scow;
 use crate::jets::hot::Hot;
 use crate::jets::warm::Warm;
 use crate::jets::JetErr;
-use crate::jets::form::util::scow;
-use crate::jets::bits::util::rap;
 use crate::mem::unifying_equality;
 use crate::mem::NockStack;
 use crate::mug::met3_usize;
@@ -20,14 +20,13 @@ use ares_macros::tas;
 use assert_no_alloc::assert_no_alloc;
 use bitvec::prelude::{BitSlice, Lsb0};
 use either::Either::*;
+use json::object;
+use std::fs::File;
+use std::io::Write;
 use std::result;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-
-use std::fs::File;
 use std::time::Instant;
-use json::object;
-use std::io::Write;
 
 crate::gdb!();
 
@@ -281,9 +280,9 @@ pub struct TraceInfo {
 }
 
 pub struct TraceStack {
-   pub start: Instant,
-   pub path: Noun,
-   pub next: *const TraceStack,
+    pub start: Instant,
+    pub path: Noun,
+    pub next: *const TraceStack,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -325,9 +324,9 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
     // Setup stack for Nock computation
     unsafe {
         context.stack.frame_push(2);
+
         // Bottom of mean stack
         *(context.stack.local_noun_pointer(0)) = D(0);
-
         // Bottom of trace stack
         *(context.stack.local_noun_pointer(1) as *mut *const TraceStack) = std::ptr::null();
 
@@ -378,14 +377,18 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
 
                     // Write fast-hinted traces to file
                     if let Some(ref mut info) = &mut context.trace_info {
-                        let mut trace_stack = *(stack.local_noun_pointer(1) as *const *const TraceStack);
+                        let mut trace_stack =
+                            *(stack.local_noun_pointer(1) as *const *const TraceStack);
                         let now = Instant::now();
                         assert_no_alloc::permit_alloc(|| {
-                            loop {
-                                if trace_stack.is_null() { break; }
-                                
-                                let ts = (*trace_stack).start.saturating_duration_since(info.process_start).as_micros() as f64;
-                                let dur = now.saturating_duration_since((*trace_stack).start).as_micros() as f64;
+                            while !trace_stack.is_null() {
+                                let ts = (*trace_stack)
+                                    .start
+                                    .saturating_duration_since(info.process_start)
+                                    .as_micros() as f64;
+                                let dur = now
+                                    .saturating_duration_since((*trace_stack).start)
+                                    .as_micros() as f64;
 
                                 // Don't write out traces less than 33us
                                 // (same threshhold used in vere)
@@ -396,33 +399,32 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
 
                                 let pc = path_to_cord(stack, (*trace_stack).path);
                                 let pclen = met3_usize(pc);
-                                if let Ok(pc_str) = std::str::from_utf8(&pc.as_bytes()[0..pclen]) {
-                                    let obj = object!{
-                                        cat: "nock",
-                                        name: pc_str,
-                                        ph: "X",
-                                        pid: info.pid,
-                                        tid: 2,
-                                        ts: ts,
-                                        dur: dur,
-                                    };
-                                    
-                                    if let Err(e) = obj.write(&mut info.file) {
-                                        eprintln!("Error writing trace to file: {:?}", e);
-                                        break;
-                                    };
+                                let pc_str = &pc.as_bytes()[0..pclen];
 
-                                    if let Err(e) = info.file.write(",\n".as_bytes()) {
-                                        eprintln!("Error writing trace to file: {:?}", e);
-                                        break;
-                                    };
+                                let obj = object! {
+                                    cat: "nock",
+                                    name: pc_str,
+                                    ph: "X",
+                                    pid: info.pid,
+                                    tid: 2,
+                                    ts: ts,
+                                    dur: dur,
+                                };
+                                if let Err(e) = obj.write(&mut info.file) {
+                                    eprintln!("\rError writing trace to file: {:?}", e);
+                                    break;
+                                };
+                                //  XX: success above but failure here permanently malforms the trace file
+                                if let Err(e) = info.file.write(",\n".as_bytes()) {
+                                    eprintln!("\rError writing trace to file: {:?}", e);
+                                    break;
+                                };
 
-                                }
                                 trace_stack = (*trace_stack).next;
                             }
                         });
                         if let Err(e) = info.file.sync_data() {
-                            eprintln!("Error syncing trace file: {:?}", e);
+                            eprintln!("\rError syncing trace file: {:?}", e);
                         };
                     }
 
@@ -696,17 +698,22 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                                 if kale.tail {
                                     stack.pop::<NockWork>();
 
-                                    if let Some(_info) = &context.trace_info {
+                                    // We could trace on 2 as well, but 2 only comes from Hoon via
+                                    // '.*', so we can assume it's never directly used to invoke
+                                    // jetted code.
+                                    if context.trace_info.is_some() {
                                         if let Some(path) = context.cold.matches(stack, &mut res) {
                                             // Push onto the tracing stack
-                                            let trace_stack = *(stack.local_noun_pointer(1) as *const *const TraceStack);
+                                            let trace_stack = *(stack.local_noun_pointer(1)
+                                                as *const *const TraceStack);
                                             let new_trace_entry = stack.struct_alloc(1);
                                             *new_trace_entry = TraceStack {
                                                 path,
                                                 start: Instant::now(),
                                                 next: trace_stack,
                                             };
-                                            *(stack.local_noun_pointer(1) as *mut *const TraceStack) = new_trace_entry;
+                                            *(stack.local_noun_pointer(1)
+                                                as *mut *const TraceStack) = new_trace_entry;
                                         };
                                     };
 
@@ -726,20 +733,24 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                                     *stack.push() = NockWork::Ret;
                                     push_formula(stack, formula, true)?;
 
-                                    if let Some(_info) = &context.trace_info {
+                                    // We could trace on 2 as well, but 2 only comes from Hoon via
+                                    // '.*', so we can assume it's never directly used to invoke
+                                    // jetted code.
+                                    if context.trace_info.is_some() {
                                         if let Some(path) = context.cold.matches(stack, &mut res) {
                                             // Push onto the tracing stack
-                                            let trace_stack = *(stack.local_noun_pointer(1) as *const *const TraceStack);
+                                            let trace_stack = *(stack.local_noun_pointer(1)
+                                                as *const *const TraceStack);
                                             let new_trace_entry = stack.struct_alloc(1);
                                             *new_trace_entry = TraceStack {
                                                 path,
                                                 start: Instant::now(),
                                                 next: trace_stack,
                                             };
-                                            *(stack.local_noun_pointer(1) as *mut *const TraceStack) = new_trace_entry;
+                                            *(stack.local_noun_pointer(1)
+                                                as *mut *const TraceStack) = new_trace_entry;
                                         };
                                     };
-
                                 }
                             } else {
                                 // Axis into core must be atom
@@ -1302,36 +1313,35 @@ pub fn inc(stack: &mut NockStack, atom: Atom) -> Atom {
     }
 }
 
+//  XX: Need Rust string interpolation helper that doesn't allocate
 fn path_to_cord(stack: &mut NockStack, path: Noun) -> Atom {
     let mut cursor = path;
     let mut length = 0usize;
 
     // count how much size we need
-    loop {
-        if let Ok(c) = cursor.as_cell() {
-            unsafe {
-                match c.head().as_either_atom_cell() {
-                    Left(a) => {
-                        length += 1;
-                        length += met3_usize(a);
-                    },
-                    Right(ch) => {
-                        if let Ok(nm) = ch.head().as_atom() {
-                            if let Ok(kv) = ch.tail().as_atom() {
-                                let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv).expect("scow should succeed in path_to_cord");
-                                let kvc = rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
-                                length += 1;
-                                length += met3_usize(nm);
-                                length += met3_usize(kvc);
-                            }
+    while let Ok(c) = cursor.as_cell() {
+        unsafe {
+            match c.head().as_either_atom_cell() {
+                Left(a) => {
+                    length += 1;
+                    length += met3_usize(a);
+                }
+                Right(ch) => {
+                    if let Ok(nm) = ch.head().as_atom() {
+                        if let Ok(kv) = ch.tail().as_atom() {
+                            let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv)
+                                .expect("scow should succeed in path_to_cord");
+                            let kvc =
+                                rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
+                            length += 1;
+                            length += met3_usize(nm);
+                            length += met3_usize(kvc);
                         }
                     }
                 }
             }
-            cursor = c.tail();
-        } else {
-            break;
         }
+        cursor = c.tail();
     }
 
     // reset cursor, then actually write the path
@@ -1339,45 +1349,41 @@ fn path_to_cord(stack: &mut NockStack, path: Noun) -> Atom {
     let mut idx = 0;
     let (mut deres, buffer) = unsafe { IndirectAtom::new_raw_mut_bytes(stack, length) };
     let slash = (b"/")[0];
-    
-    loop {
-        if let Ok(c) = cursor.as_cell() {
-            unsafe {
-                match c.head().as_either_atom_cell() {
-                    Left(a) => {
-                        buffer[idx] = slash;
-                        idx += 1;
-                        let bytelen = met3_usize(a);
-                        buffer[idx..idx+bytelen].copy_from_slice(&a.as_bytes()[0..bytelen]);
-                        idx += bytelen;
-                    },
-                    Right(ch) => {
-                        if let Ok(nm) = ch.head().as_atom() {
-                            if let Ok(kv) = ch.tail().as_atom() {
-                                let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv).expect("scow should succeed in path_to_cord");
-                                let kvc = rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
-                                buffer[idx] = slash;
-                                idx += 1;
-                                let nmlen = met3_usize(nm);
-                                buffer[idx..idx+nmlen].copy_from_slice(&nm.as_bytes()[0..nmlen]);
-                                idx += nmlen;
-                                let kvclen = met3_usize(kvc);
-                                buffer[idx..idx+kvclen].copy_from_slice(&kvc.as_bytes()[0..kvclen]);
-                                idx += kvclen;
-                            }
+
+    while let Ok(c) = cursor.as_cell() {
+        unsafe {
+            match c.head().as_either_atom_cell() {
+                Left(a) => {
+                    buffer[idx] = slash;
+                    idx += 1;
+                    let bytelen = met3_usize(a);
+                    buffer[idx..idx + bytelen].copy_from_slice(&a.as_bytes()[0..bytelen]);
+                    idx += bytelen;
+                }
+                Right(ch) => {
+                    if let Ok(nm) = ch.head().as_atom() {
+                        if let Ok(kv) = ch.tail().as_atom() {
+                            let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv)
+                                .expect("scow should succeed in path_to_cord");
+                            let kvc =
+                                rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
+                            buffer[idx] = slash;
+                            idx += 1;
+                            let nmlen = met3_usize(nm);
+                            buffer[idx..idx + nmlen].copy_from_slice(&nm.as_bytes()[0..nmlen]);
+                            idx += nmlen;
+                            let kvclen = met3_usize(kvc);
+                            buffer[idx..idx + kvclen].copy_from_slice(&kvc.as_bytes()[0..kvclen]);
+                            idx += kvclen;
                         }
-                    },
+                    }
                 }
             }
-            cursor = c.tail();
-        } else {
-            break;
         }
-    };
-    
-    unsafe {
-        deres.normalize_as_atom()
+        cursor = c.tail();
     }
+
+    unsafe { deres.normalize_as_atom() }
 }
 
 mod hint {
@@ -1688,4 +1694,3 @@ mod hint {
         newt.slog(stack, 0u64, tank);
     }
 }
-

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -1246,7 +1246,7 @@ unsafe fn write_trace(context: &mut Context) {
         // Abort writing to trace file if we encountered an error. This should
         // result in a well-formed partial trace file.
         if let Err(e) = write_nock_trace(&mut context.stack, info, trace_stack) {
-            eprintln!("\rError writing trace to file: {:?}", e);
+            eprintln!("\rserf: error writing nock trace to file: {:?}", e);
             context.trace_info = None;
         }
     }

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -387,6 +387,13 @@ pub fn interpret(context: &mut Context, mut subject: Noun, formula: Noun) -> Res
                                 let ts = (*trace_stack).start.saturating_duration_since(info.process_start).as_micros() as f64;
                                 let dur = now.saturating_duration_since((*trace_stack).start).as_micros() as f64;
 
+                                // Don't write out traces less than 33us
+                                // (same threshhold used in vere)
+                                if dur < 33.0 {
+                                    trace_stack = (*trace_stack).next;
+                                    continue;
+                                }
+
                                 let pc = path_to_cord(stack, (*trace_stack).path);
                                 let pclen = met3_usize(pc);
                                 if let Ok(pc_str) = std::str::from_utf8(&pc.as_bytes()[0..pclen]) {

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -268,6 +268,7 @@ pub mod util {
                 hot,
                 cache,
                 scry_stack: D(0),
+                trace_info: None,
             }
         }
 

--- a/rust/ares/src/jets/cold.rs
+++ b/rust/ares/src/jets/cold.rs
@@ -274,8 +274,8 @@ struct ColdMem {
     /// value: possible registered paths for core
     ///
     /// Identical nock can exist in multiple places, so the outermost battery
-    /// yield multiple paths. Instead of matching on the entire core in the Hamt
-    /// (which would require iterating through every possible pait), we match
+    /// yields multiple paths. Instead of matching on the entire core in the Hamt
+    /// (which would require iterating through every possible pair), we match
     /// the outermost battery to a path, then compare the core to the registered
     /// cores for that path.
     battery_to_paths: Hamt<NounList>,
@@ -348,15 +348,16 @@ impl Cold {
         unsafe {
             let paths = (*(self.0)).battery_to_paths.lookup(stack, &mut battery)?;
             for path in paths {
-                if let Some(batteries_list) = (*(self.0)).path_to_batteries.lookup(stack, &mut (*path)) {
-
+                if let Some(batteries_list) =
+                    (*(self.0)).path_to_batteries.lookup(stack, &mut (*path))
+                {
                     if let Some(_batt) = batteries_list.matches(stack, *core) {
                         return Some(*path);
                     }
                 }
-            };
-            return None;
-        }
+            }
+        };
+        None
     }
 
     /// register a core, return a boolean of whether we actually needed to register (false ->

--- a/rust/ares/src/jets/cold.rs
+++ b/rust/ares/src/jets/cold.rs
@@ -341,6 +341,24 @@ impl Cold {
         }
     }
 
+    /** Try to match a core directly to the cold state, print the resulting path if found
+     */
+    pub fn matches(&mut self, stack: &mut NockStack, core: &mut Noun) -> Option<Noun> {
+        let mut battery = (*core).slot(2).ok()?;
+        unsafe {
+            let paths = (*(self.0)).battery_to_paths.lookup(stack, &mut battery)?;
+            for path in paths {
+                if let Some(batteries_list) = (*(self.0)).path_to_batteries.lookup(stack, &mut (*path)) {
+
+                    if let Some(_batt) = batteries_list.matches(stack, *core) {
+                        return Some(*path);
+                    }
+                }
+            };
+            return None;
+        }
+    }
+
     /// register a core, return a boolean of whether we actually needed to register (false ->
     /// already registered)
     ///

--- a/rust/ares/src/lib.rs
+++ b/rust/ares/src/lib.rs
@@ -3,6 +3,7 @@ extern crate num_derive;
 extern crate lazy_static;
 #[macro_use]
 extern crate static_assertions;
+pub mod hamt;
 pub mod interpreter;
 pub mod jets;
 pub mod mem;
@@ -11,9 +12,9 @@ pub mod newt;
 pub mod noun;
 pub mod serf;
 //pub mod bytecode;
-pub mod hamt;
 pub mod serialization;
 pub mod snapshot;
+pub mod trace;
 
 /** Introduce useful functions for debugging
  *

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -79,6 +79,7 @@ fn main() -> io::Result<()> {
         warm,
         hot,
         scry_stack: D(0),
+        trace_info: None,
     };
     let result =
         interpret(&mut context, input_cell.head(), input_cell.tail()).expect("nock failed");
@@ -103,3 +104,4 @@ fn main() -> io::Result<()> {
     };
     Ok(())
 }
+

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -104,4 +104,3 @@ fn main() -> io::Result<()> {
     };
     Ok(())
 }
-

--- a/rust/ares/src/mug.rs
+++ b/rust/ares/src/mug.rs
@@ -20,7 +20,7 @@ fn muk_u32(syd: u32, len: usize, key: Atom) -> u32 {
  *
  * Assumes atom is normalized
  */
-fn met3_usize(atom: Atom) -> usize {
+pub fn met3_usize(atom: Atom) -> usize {
     match atom.as_either() {
         Left(direct) => (64 - (direct.data().leading_zeros() as usize) + 7) >> 3,
         Right(indirect) => {

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -292,7 +292,6 @@ fn peek(context: &mut Context, ovo: Noun) -> Noun {
     if context.nock_context.trace_info.is_some() {
         //  XX: way too many cases in the input to pull the actual vane, care, and path out
         let trace_name = "peek";
-
         let _ = write_serf_trace_start(
             context.nock_context.trace_info.as_mut().unwrap(),
             trace_name,
@@ -301,7 +300,7 @@ fn peek(context: &mut Context, ovo: Noun) -> Noun {
 
         // Abort writing to trace file if we encountered an error. This should result in a
         // well-formed partial trace file.
-        if let Err(e) = write_serf_trace_start(
+        if let Err(e) = write_serf_trace_end(
             context.nock_context.trace_info.as_mut().unwrap(),
             trace_name,
         ) {
@@ -368,7 +367,30 @@ fn play_life(context: &mut Context, eve: Noun) {
     let stack = &mut context.nock_context.stack;
     let sub = T(stack, &[D(0), D(3)]);
     let lyf = T(stack, &[D(2), sub, D(0), D(2)]);
-    match interpret(&mut context.nock_context, eve, lyf) {
+    let res = if context.nock_context.trace_info.is_some() {
+        let trace_name = "boot";
+        let _ = write_serf_trace_start(
+            context.nock_context.trace_info.as_mut().unwrap(),
+            trace_name,
+        );
+        let boot_res = interpret(&mut context.nock_context, eve, lyf);
+
+        // Abort writing to trace file if we encountered an error. This should result in a
+        // well-formed partial trace file.
+        if let Err(e) = write_serf_trace_end(
+            context.nock_context.trace_info.as_mut().unwrap(),
+            trace_name,
+        ) {
+            eprintln!("\rserf: error writing event trace to file: {:?}", e);
+            context.nock_context.trace_info = None;
+        }
+
+        boot_res
+    } else {
+        interpret(&mut context.nock_context, eve, lyf)
+    };
+
+    match res {
         Ok(gat) => {
             let eved = lent(eve).expect("serf: play: boot event number failure") as u64;
             let arvo = slot(gat, 7).expect("serf: play: lifecycle didn't return initial Arvo");

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -295,16 +295,7 @@ fn peek(context: &mut Context, ovo: Noun) -> Noun {
         let trace_name = "peek";
         let start = Instant::now();
         let slam_res = slam(context, PEEK_AXIS, ovo);
-        // Abort writing to trace file if we encountered an error. This should result in a
-        // well-formed partial trace file.
-        if let Err(e) = write_serf_trace(
-            context.nock_context.trace_info.as_mut().unwrap(),
-            trace_name,
-            start,
-        ) {
-            eprintln!("\rserf: error writing event trace to file: {:?}", e);
-            context.nock_context.trace_info = None;
-        }
+        write_serf_trace_safe(&mut context.nock_context.trace_info, trace_name, start);
 
         slam_res.expect("peek error handling unimplemented")
     } else {
@@ -331,17 +322,11 @@ fn soft(context: &mut Context, ovo: Noun, trace_name: Option<String>) -> Result<
     let slam_res = if context.nock_context.trace_info.is_some() {
         let start = Instant::now();
         let slam_res = slam(context, POKE_AXIS, ovo);
-
-        // Abort writing to trace file if we encountered an error. This should result in a
-        // well-formed partial trace file.
-        if let Err(e) = write_serf_trace(
-            context.nock_context.trace_info.as_mut().unwrap(),
+        write_serf_trace_safe(
+            &mut context.nock_context.trace_info,
             trace_name.as_ref().unwrap(),
             start,
-        ) {
-            eprintln!("\rserf: error writing event trace to file: {:?}", e);
-            context.nock_context.trace_info = None;
-        }
+        );
 
         slam_res
     } else {
@@ -369,16 +354,7 @@ fn play_life(context: &mut Context, eve: Noun) {
         let trace_name = "boot";
         let start = Instant::now();
         let boot_res = interpret(&mut context.nock_context, eve, lyf);
-        // Abort writing to trace file if we encountered an error. This should result in a
-        // well-formed partial trace file.
-        if let Err(e) = write_serf_trace(
-            context.nock_context.trace_info.as_mut().unwrap(),
-            trace_name,
-            start,
-        ) {
-            eprintln!("\rserf: error writing event trace to file: {:?}", e);
-            context.nock_context.trace_info = None;
-        }
+        write_serf_trace_safe(&mut context.nock_context.trace_info, trace_name, start);
 
         boot_res
     } else {

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -208,7 +208,10 @@ pub fn serf() -> io::Result<()> {
     };
 
     if let Some(ref mut info) = trace_info.as_mut() {
-        write_metadata(info);
+        if let Err(e) = write_metadata(info) {
+            eprintln!("\rError initializing trace file: {:?}", e);
+            trace_info = None;
+        }
     }
 
     let mut context = Context::new(&snap_path, trace_info);

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -75,7 +75,7 @@ pub fn write_metadata(info: &mut TraceInfo) -> Result<(), Error> {
         name: "thread_name",
         ph: "M",
         pid: info.pid,
-        tid: 1,             //  XX: get tid in Rust
+        tid: 1,
         args: object!{ name: "Event Processing", },
     })
     .write(&mut info.file)?;
@@ -85,28 +85,8 @@ pub fn write_metadata(info: &mut TraceInfo) -> Result<(), Error> {
         name: "thread_sort_index",
         ph: "M",
         pid: info.pid,
-        tid: 1,             //  XX: get tid in Rust
+        tid: 1,
         args: object!{ sort_index: 1, },
-    })
-    .write(&mut info.file)?;
-    info.file.write_all(",\n".as_bytes())?;
-
-    (object! {
-        name: "thread_name",
-        ph: "M",
-        pid: info.pid,
-        tid: 2,             //  XX: get tid in Rust
-        args: object!{ name: "Nock", },
-    })
-    .write(&mut info.file)?;
-    info.file.write_all(",\n".as_bytes())?;
-
-    (object! {
-        name: "thread_sort_index",
-        ph: "M",
-        pid: info.pid,
-        tid: 2,             //  XX: get tid in Rust
-        args: object!{ sort_index: 2, },
     })
     .write(&mut info.file)?;
     info.file.write_all(",\n".as_bytes())?;
@@ -137,7 +117,7 @@ pub fn write_serf_trace(info: &mut TraceInfo, name: &str, start: Instant) -> Res
             name: name,
             ph: "X",
             pid: info.pid,
-            tid: 1,             //  XX: get tid in Rust
+            tid: 1,
             ts: ts,
             dur: dur,
         };
@@ -188,7 +168,7 @@ pub unsafe fn write_nock_trace(
                 name: pc_str,
                 ph: "X",
                 pid: info.pid,
-                tid: 2,             //  XX: get tid in Rust
+                tid: 1,
                 ts: ts,
                 dur: dur,
             };

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -115,6 +115,16 @@ pub fn write_metadata(info: &mut TraceInfo) -> Result<(), Error> {
     Ok(())
 }
 
+/// Abort writing to trace file if an error is encountered.
+///
+/// This should result in a well-formed partial trace file.
+pub fn write_serf_trace_safe(info: &mut Option<TraceInfo>, name: &str, start: Instant) {
+    if let Err(e) = write_serf_trace(info.as_mut().unwrap(), name, start) {
+        eprintln!("\rserf: error writing event trace to file: {:?}", e);
+        *info = None;
+    }
+}
+
 pub fn write_serf_trace(info: &mut TraceInfo, name: &str, start: Instant) -> Result<(), Error> {
     let ts = start
         .saturating_duration_since(info.process_start)

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -1,0 +1,244 @@
+use crate::jets::bits::util::rap;
+use crate::jets::form::util::scow;
+use crate::mem::NockStack;
+use crate::mug::met3_usize;
+use crate::noun::{Atom, DirectAtom, IndirectAtom, Noun};
+use ares_macros::tas;
+use either::Either::*;
+use json::object;
+use std::fs::{create_dir_all, File};
+use std::io::{Error, Write};
+use std::path::PathBuf;
+use std::result::Result;
+use std::time::Instant;
+
+crate::gdb!();
+
+pub struct TraceInfo {
+    pub file: File,
+    pub pid: u32,
+    pub process_start: Instant,
+}
+
+pub struct TraceStack {
+    pub start: Instant,
+    pub path: Noun,
+    pub next: *const TraceStack,
+}
+
+pub fn create_trace_file(pier_path: PathBuf) -> Result<TraceInfo, Error> {
+    let mut trace_dir_path = pier_path.clone();
+    trace_dir_path.push(".urb");
+    trace_dir_path.push("put");
+    trace_dir_path.push("trace");
+    create_dir_all(&trace_dir_path)?;
+
+    let trace_path: PathBuf;
+    let mut trace_idx = 0u32;
+    loop {
+        let mut prospective_path = trace_dir_path.clone();
+        prospective_path.push(format!("{}.json", trace_idx));
+
+        if prospective_path.exists() {
+            trace_idx += 1;
+        } else {
+            trace_path = prospective_path.clone();
+            break;
+        }
+    }
+
+    let file = File::create(trace_path)?;
+    let process_start = Instant::now();
+    let pid = std::process::id();
+
+    Ok(TraceInfo {
+        file,
+        pid,
+        process_start,
+    })
+}
+
+/// Write metadata to trace file
+pub fn write_metadata(info: &mut TraceInfo) {
+    info.file.write_all("[ ".as_bytes());
+
+    (object! {
+        name: "process_name",
+        ph: "M",
+        pid: info.pid,
+        args: object! { name: "urbit", },
+    })
+    .write(&mut info.file);
+    info.file.write_all(",\n".as_bytes());
+
+    (object! {
+        name: "thread_name",
+        ph: "M",
+        pid: info.pid,
+        tid: 1,
+        args: object!{ name: "Event Processing", },
+    })
+    .write(&mut info.file);
+    info.file.write_all(",\n".as_bytes());
+
+    (object! {
+        name: "thread_sort_index",
+        ph: "M",
+        pid: info.pid,
+        tid: 1,
+        args: object!{ sort_index: 1, },
+    })
+    .write(&mut info.file);
+    info.file.write_all(",\n".as_bytes());
+
+    (object! {
+        name: "thread_name",
+        ph: "M",
+        pid: info.pid,
+        tid: 2,
+        args: object!{ name: "Nock", },
+    })
+    .write(&mut info.file);
+    info.file.write_all(",\n".as_bytes());
+
+    (object! {
+        name: "thread_sort_index",
+        ph: "M",
+        pid: info.pid,
+        tid: 2,
+        args: object!{ sort_index: 2, },
+    })
+    .write(&mut info.file);
+    info.file.write_all(",\n".as_bytes());
+
+    info.file.sync_data();
+}
+
+pub fn write_nock_trace(
+    stack: &mut NockStack,
+    info: &mut TraceInfo,
+    mut trace_stack: *const TraceStack,
+) {
+    let now = Instant::now();
+    unsafe {
+        assert_no_alloc::permit_alloc(|| {
+            while !trace_stack.is_null() {
+                let ts = (*trace_stack)
+                    .start
+                    .saturating_duration_since(info.process_start)
+                    .as_micros() as f64;
+                let dur = now
+                    .saturating_duration_since((*trace_stack).start)
+                    .as_micros() as f64;
+
+                // Don't write out traces less than 33us
+                // (same threshhold used in vere)
+                if dur < 33.0 {
+                    trace_stack = (*trace_stack).next;
+                    continue;
+                }
+
+                let pc = path_to_cord(stack, (*trace_stack).path);
+                let pclen = met3_usize(pc);
+                let pc_str = &pc.as_bytes()[0..pclen];
+
+                let obj = object! {
+                    cat: "nock",
+                    name: pc_str,
+                    ph: "X",
+                    pid: info.pid,
+                    tid: 2,
+                    ts: ts,
+                    dur: dur,
+                };
+                if let Err(e) = obj.write(&mut info.file) {
+                    eprintln!("\rError writing trace to file: {:?}", e);
+                    break;
+                };
+                //  XX: success above but failure here permanently malforms the trace file
+                if let Err(e) = info.file.write(",\n".as_bytes()) {
+                    eprintln!("\rError writing trace to file: {:?}", e);
+                    break;
+                };
+
+                trace_stack = (*trace_stack).next;
+            }
+        });
+    }
+    if let Err(e) = info.file.sync_data() {
+        eprintln!("\rError syncing trace file: {:?}", e);
+    };
+}
+
+//  XX: Need Rust string interpolation helper that doesn't allocate
+fn path_to_cord(stack: &mut NockStack, path: Noun) -> Atom {
+    let mut cursor = path;
+    let mut length = 0usize;
+
+    // count how much size we need
+    while let Ok(c) = cursor.as_cell() {
+        unsafe {
+            match c.head().as_either_atom_cell() {
+                Left(a) => {
+                    length += 1;
+                    length += met3_usize(a);
+                }
+                Right(ch) => {
+                    if let Ok(nm) = ch.head().as_atom() {
+                        if let Ok(kv) = ch.tail().as_atom() {
+                            let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv)
+                                .expect("scow should succeed in path_to_cord");
+                            let kvc =
+                                rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
+                            length += 1;
+                            length += met3_usize(nm);
+                            length += met3_usize(kvc);
+                        }
+                    }
+                }
+            }
+        }
+        cursor = c.tail();
+    }
+
+    // reset cursor, then actually write the path
+    cursor = path;
+    let mut idx = 0;
+    let (mut deres, buffer) = unsafe { IndirectAtom::new_raw_mut_bytes(stack, length) };
+    let slash = (b"/")[0];
+
+    while let Ok(c) = cursor.as_cell() {
+        unsafe {
+            match c.head().as_either_atom_cell() {
+                Left(a) => {
+                    buffer[idx] = slash;
+                    idx += 1;
+                    let bytelen = met3_usize(a);
+                    buffer[idx..idx + bytelen].copy_from_slice(&a.as_bytes()[0..bytelen]);
+                    idx += bytelen;
+                }
+                Right(ch) => {
+                    if let Ok(nm) = ch.head().as_atom() {
+                        if let Ok(kv) = ch.tail().as_atom() {
+                            let kvt = scow(stack, DirectAtom::new_unchecked(tas!(b"ud")), kv)
+                                .expect("scow should succeed in path_to_cord");
+                            let kvc =
+                                rap(stack, 3, kvt).expect("rap should succeed in path_to_cord");
+                            buffer[idx] = slash;
+                            idx += 1;
+                            let nmlen = met3_usize(nm);
+                            buffer[idx..idx + nmlen].copy_from_slice(&nm.as_bytes()[0..nmlen]);
+                            idx += nmlen;
+                            let kvclen = met3_usize(kvc);
+                            buffer[idx..idx + kvclen].copy_from_slice(&kvc.as_bytes()[0..kvclen]);
+                            idx += kvclen;
+                        }
+                    }
+                }
+            }
+        }
+        cursor = c.tail();
+    }
+
+    unsafe { deres.normalize_as_atom() }
+}

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -139,8 +139,15 @@ pub unsafe fn write_nock_trace(
         }
 
         let pc = path_to_cord(stack, (*trace_stack).path);
-        let pclen = met3_usize(pc);
-        let pc_str = &pc.as_bytes()[0..pclen];
+        let pc_len = met3_usize(pc);
+        let pc_bytes = &pc.as_bytes()[0..pc_len];
+        let pc_str = match std::str::from_utf8(pc_bytes) {
+            Ok(valid) => valid,
+            Err(error) => {
+                let (valid, _) = pc_bytes.split_at(error.valid_up_to());
+                unsafe { std::str::from_utf8_unchecked(valid) }
+            }
+        };
 
         assert_no_alloc::permit_alloc(|| {
             let obj = object! {

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -115,29 +115,21 @@ pub fn write_metadata(info: &mut TraceInfo) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn write_serf_trace_start(info: &mut TraceInfo, name: &str) -> Result<(), Error> {
-    let phase = "B";
-    write_serf_trace_event(info, name, phase)
-}
-
-pub fn write_serf_trace_end(info: &mut TraceInfo, name: &str) -> Result<(), Error> {
-    let phase = "E";
-    write_serf_trace_event(info, name, phase)
-}
-
-pub fn write_serf_trace_event(info: &mut TraceInfo, name: &str, phase: &str) -> Result<(), Error> {
-    let ts = Instant::now()
+pub fn write_serf_trace(info: &mut TraceInfo, name: &str, start: Instant) -> Result<(), Error> {
+    let ts = start
         .saturating_duration_since(info.process_start)
         .as_micros() as f64;
+    let dur = Instant::now().saturating_duration_since(start).as_micros() as f64;
 
     assert_no_alloc::permit_alloc(|| {
         let obj = object! {
             cat: "event",
             name: name,
-            ph: phase,
+            ph: "X",
             pid: info.pid,
             tid: 1,             //  XX: get tid in Rust
             ts: ts,
+            dur: dur,
         };
         obj.write(&mut info.file)
     })?;


### PR DESCRIPTION
@ashelkovnykov since this builds off the demo-debug work and in particular the cold-state matching, I'm targeting it at your demo-debug cleanup branch

This PR adds event-tracing profiling (-j in the king) to Ares.

TODO:
- [x] log fast-hinted core invocations
- [x] omit invocations with duration <33us
- [x] trace serf events