### PR TITLE
Add u64/u128 atom exports

### DIFF
--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -751,14 +751,12 @@ impl Atom {
             let mut u128_array = &mut [0u64; 2];
             u128_array[0] = 0x0 as u64;
             u128_array[1] = self.as_direct()?.data() as u64;
-            Ok(unsafe { *u128_array } )
+            Ok(unsafe { *u128_array })
         } else {
-            unsafe {
-                self.indirect.as_u128_pair()
-            }
+            unsafe { self.indirect.as_u128_pair() }
         }
     }
-    
+
     pub fn as_bitslice(&self) -> &BitSlice<u64, Lsb0> {
         if self.is_indirect() {
             unsafe { self.indirect.as_bitslice() }

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -473,7 +473,7 @@ impl IndirectAtom {
     }
 
     /** Produce a SoftFloat-compatible ordered pair of 64-bit words */
-    pub unsafe fn as_u64_pair(self) -> Result<[u64; 2]> {
+    pub fn as_u64_pair(self) -> Result<[u64; 2]> {
         if self.size() <= 2 {
             let u128_array = &mut [0u64; 2];
             u128_array.copy_from_slice(&(self.as_slice()[0..2]));

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -472,7 +472,8 @@ impl IndirectAtom {
         }
     }
 
-    pub unsafe fn as_u128_pair(self) -> Result<[u64; 2]> {
+    /* SoftFloat-compatible ordered pair of 64-bit words */
+    pub unsafe fn as_u64_pair(self) -> Result<[u64; 2]> {
         if self.size() <= 2 {
             let u128_array = &mut [0u64; 2];
             u128_array.copy_from_slice(&(self.as_slice()[0..2]));
@@ -764,14 +765,15 @@ impl Atom {
         }
     }
 
-    pub unsafe fn as_u128_pair(self) -> Result<[u64; 2]> {
+    /* SoftFloat-compatible ordered pair of 64-bit words */
+    pub unsafe fn as_u64_pair(self) -> Result<[u64; 2]> {
         if self.is_direct() {
             let u128_array = &mut [0u64; 2];
             u128_array[0] = 0x0_u64;
             u128_array[1] = self.as_direct()?.data();
             Ok(*u128_array)
         } else {
-            unsafe { self.indirect.as_u128_pair() }
+            unsafe { self.indirect.as_u64_pair() }
         }
     }
 

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -742,9 +742,7 @@ impl Atom {
         if self.is_direct() {
             Ok(unsafe { self.direct.data() })
         } else {
-            unsafe {
-                self.indirect.as_u64()
-            }
+            unsafe { self.indirect.as_u64() }
         }
     }
 
@@ -842,7 +840,7 @@ impl Atom {
         if self.size() <= 2 {
             let mut u128_array = &mut [0u64; 2];
             u128_array.copy_from_slice(&(self.as_slice()[0..2]));
-            Ok(unsafe { *u128_array } )
+            Ok(unsafe { *u128_array })
         } else {
             Err(Error::NotRepresentable)
         }

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -769,8 +769,8 @@ impl Atom {
     pub unsafe fn as_u64_pair(self) -> Result<[u64; 2]> {
         if self.is_direct() {
             let u128_array = &mut [0u64; 2];
-            u128_array[0] = 0x0_u64;
-            u128_array[1] = self.as_direct()?.data();
+            u128_array[0] = self.as_direct()?.data();
+            u128_array[1] = 0x0_u64;
             Ok(*u128_array)
         } else {
             unsafe { self.indirect.as_u64_pair() }

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -464,6 +464,24 @@ impl IndirectAtom {
         UBig::from_le_bytes_stack(stack, self.as_bytes())
     }
 
+    pub unsafe fn as_u64(self) -> Result<u64> {
+        if self.size() == 1 {
+            Ok(*(self.data_pointer()))
+        } else {
+            Err(Error::NotRepresentable)
+        }
+    }
+
+    pub unsafe fn as_u128_pair(self) -> Result<[u64; 2]> {
+        if self.size() <= 2 {
+            let mut u128_array = &mut [0u64; 2];
+            u128_array.copy_from_slice(&(self.as_slice()[0..2]));
+            Ok(unsafe { *u128_array })
+        } else {
+            Err(Error::NotRepresentable)
+        }
+    }
+
     /** Ensure that the size does not contain any trailing 0 words */
     pub unsafe fn normalize(&mut self) -> &Self {
         let mut index = self.size() - 1;
@@ -823,24 +841,6 @@ impl Atom {
             self.indirect.normalize_as_atom()
         } else {
             *self
-        }
-    }
-
-    pub unsafe fn as_u64(self) -> Result<u64> {
-        if self.size() == 1 {
-            Ok(*(self.data_pointer()))
-        } else {
-            Err(Error::NotRepresentable)
-        }
-    }
-
-    pub unsafe fn as_u128_pair(self) -> Result<[u64; 2]> {
-        if self.size() <= 2 {
-            let mut u128_array = &mut [0u64; 2];
-            u128_array.copy_from_slice(&(self.as_slice()[0..2]));
-            Ok(unsafe { *u128_array })
-        } else {
-            Err(Error::NotRepresentable)
         }
     }
 

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -472,7 +472,7 @@ impl IndirectAtom {
         }
     }
 
-    /* SoftFloat-compatible ordered pair of 64-bit words */
+    /** Produce a SoftFloat-compatible ordered pair of 64-bit words */
     pub unsafe fn as_u64_pair(self) -> Result<[u64; 2]> {
         if self.size() <= 2 {
             let u128_array = &mut [0u64; 2];
@@ -765,7 +765,7 @@ impl Atom {
         }
     }
 
-    /* SoftFloat-compatible ordered pair of 64-bit words */
+    /** Produce a SoftFloat-compatible ordered pair of 64-bit words */
     pub unsafe fn as_u64_pair(self) -> Result<[u64; 2]> {
         if self.is_direct() {
             let u128_array = &mut [0u64; 2];

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -474,9 +474,9 @@ impl IndirectAtom {
 
     pub unsafe fn as_u128_pair(self) -> Result<[u64; 2]> {
         if self.size() <= 2 {
-            let mut u128_array = &mut [0u64; 2];
+            let u128_array = &mut [0u64; 2];
             u128_array.copy_from_slice(&(self.as_slice()[0..2]));
-            Ok(unsafe { *u128_array })
+            Ok(*u128_array)
         } else {
             Err(Error::NotRepresentable)
         }
@@ -766,10 +766,10 @@ impl Atom {
 
     pub unsafe fn as_u128_pair(self) -> Result<[u64; 2]> {
         if self.is_direct() {
-            let mut u128_array = &mut [0u64; 2];
-            u128_array[0] = 0x0 as u64;
-            u128_array[1] = self.as_direct()?.data() as u64;
-            Ok(unsafe { *u128_array })
+            let u128_array = &mut [0u64; 2];
+            u128_array[0] = 0x0_u64;
+            u128_array[1] = self.as_direct()?.data();
+            Ok(*u128_array)
         } else {
             unsafe { self.indirect.as_u128_pair() }
         }


### PR DESCRIPTION
Necessary for floating-point; nice for conversions from direct atoms.

In particular, I'd like this expedited to complete `last` in the parsing jets.