### PR TITLE
serf: fix bug that would abandon arvo state

### DIFF
--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -244,6 +244,7 @@ pub fn serf() -> io::Result<()> {
         //  XX: Such data should go in the PMA once that's available
         unsafe {
             let stack = &mut context.nock_context.stack;
+            stack.preserve(&mut context.arvo);
             stack.preserve(&mut context.nock_context.cold);
             stack.preserve(&mut context.nock_context.warm);
             stack.frame_pop();


### PR DESCRIPTION
Caught by @philipquirk: when I added the extra frame push to preserve warm/cold state, I forgot to preserve the new Arvo state produced by the event.