### PR TITLE
devenv: add libiconv to shell.nix

### DIFF
--- a/rust/shell.nix
+++ b/rust/shell.nix
@@ -14,5 +14,6 @@ pkgs.mkShell {
     ])
     cargo-watch
     gdb
+    libiconv
   ];
 }


### PR DESCRIPTION
Couldn't run `cargo build` on m1 mac without this dependency.