### PR TITLE
Disable all `eprintln!` calls which perform string interpolation

### DIFF
--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -1226,7 +1226,8 @@ unsafe fn write_trace(context: &mut Context) {
         // Abort writing to trace file if we encountered an error. This should
         // result in a well-formed partial trace file.
         if let Err(e) = write_nock_trace(&mut context.stack, info, trace_stack) {
-            eprintln!("\rserf: error writing nock trace to file: {:?}", e);
+            //  XX: need NockStack allocated string interpolation
+            // eprintln!("\rserf: error writing nock trace to file: {:?}", e);
             context.trace_info = None;
         }
     }
@@ -1291,15 +1292,10 @@ mod hint {
                                                     &mut jet_res,
                                                 )
                                             } {
-                                                //  XX: need string interpolation without allocation, then delete eprintln
+                                                //  XX: need NockStack allocated string interpolation
                                                 // let tape = tape(stack, "jet mismatch in {}, raw: {}, jetted: {}", jet_name, nock_res, jet_res);
-                                                eprintln!(
-                                                    "\rjet {} failed, raw: {:?}, jetted: {}",
-                                                    jet_name, nock_res, jet_res
-                                                );
-                                                let tape = tape(stack, "jet mismatch");
-                                                let mean = T(stack, &[D(tas!(b"mean")), tape]);
-                                                mean_push(stack, mean);
+                                                // let mean = T(stack, &[D(tas!(b"mean")), tape]);
+                                                // mean_push(stack, mean);
                                                 Some(Err(Error::Deterministic(D(0))))
                                             } else {
                                                 Some(Ok(nock_res))
@@ -1307,15 +1303,10 @@ mod hint {
                                         }
                                         Err(error) => {
                                             let stack = &mut context.stack;
-                                            //  XX: need string interpolation without allocation, then delete eprintln
+                                            //  XX: need NockStack allocated string interpolation
                                             // let tape = tape(stack, "jet mismatch in {}, raw: {}, jetted: {}", jet_name, err, jet_res);
-                                            eprintln!(
-                                                "\rjet {} failed, raw: {:?}, jetted: {}",
-                                                jet_name, error, jet_res
-                                            );
-                                            let tape = tape(stack, "jet mismatch");
-                                            let mean = T(stack, &[D(tas!(b"mean")), tape]);
-                                            mean_push(stack, mean);
+                                            // let mean = T(stack, &[D(tas!(b"mean")), tape]);
+                                            // mean_push(stack, mean);
 
                                             match error {
                                                 Error::NonDeterministic(_) => {
@@ -1332,11 +1323,10 @@ mod hint {
                             Err(JetErr::Punt) => None,
                             Err(err) => {
                                 let stack = &mut context.stack;
-                                //  XX: need string interpolation without allocation
+                                //  XX: need NockStack allocated string interpolation
                                 // let tape = tape(stack, "{} jet error in {}", err, jet_name);
-                                let tape = tape(stack, "jet error");
-                                let mean = T(stack, &[D(tas!(b"mean")), tape]);
-                                mean_push(stack, mean);
+                                // let mean = T(stack, &[D(tas!(b"mean")), tape]);
+                                // mean_push(stack, mean);
                                 Some(Err(err.into()))
                             }
                         }

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -1225,7 +1225,7 @@ unsafe fn write_trace(context: &mut Context) {
         let trace_stack = *(context.stack.local_noun_pointer(1) as *mut *const TraceStack);
         // Abort writing to trace file if we encountered an error. This should
         // result in a well-formed partial trace file.
-        if let Err(e) = write_nock_trace(&mut context.stack, info, trace_stack) {
+        if let Err(_e) = write_nock_trace(&mut context.stack, info, trace_stack) {
             //  XX: need NockStack allocated string interpolation
             // eprintln!("\rserf: error writing nock trace to file: {:?}", e);
             context.trace_info = None;
@@ -1302,8 +1302,8 @@ mod hint {
                                             }
                                         }
                                         Err(error) => {
-                                            let stack = &mut context.stack;
                                             //  XX: need NockStack allocated string interpolation
+                                            // let stack = &mut context.stack;
                                             // let tape = tape(stack, "jet mismatch in {}, raw: {}, jetted: {}", jet_name, err, jet_res);
                                             // let mean = T(stack, &[D(tas!(b"mean")), tape]);
                                             // mean_push(stack, mean);
@@ -1322,8 +1322,8 @@ mod hint {
                             }
                             Err(JetErr::Punt) => None,
                             Err(err) => {
-                                let stack = &mut context.stack;
                                 //  XX: need NockStack allocated string interpolation
+                                // let stack = &mut context.stack;
                                 // let tape = tape(stack, "{} jet error in {}", err, jet_name);
                                 // let mean = T(stack, &[D(tas!(b"mean")), tape]);
                                 // mean_push(stack, mean);

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -148,6 +148,7 @@ pub fn get_jet(jet_name: Noun) -> Option<Jet> {
         tas!(b"sivc_de") => Some(jet_sivc_de),
         //
         _ => {
+            //  XX: need NockStack allocated string interpolation
             // eprintln!("Unknown jet: {:?}", jet_name);
             None
         }

--- a/rust/ares/src/jets/warm.rs
+++ b/rust/ares/src/jets/warm.rs
@@ -122,7 +122,8 @@ impl Warm {
                 if let Ok(mut formula) = unsafe { (*battery).slot_atom(axis) } {
                     warm.insert(stack, &mut formula, path, batteries, jet);
                 } else {
-                    eprintln!("Bad axis {} into formula {:?}", axis, battery);
+                    //  XX: need NockStack allocated string interpolation
+                    // eprintln!("Bad axis {} into formula {:?}", axis, battery);
                     continue;
                 }
             }

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -19,6 +19,7 @@ use std::ptr::copy_nonoverlapping;
 use std::ptr::write_bytes;
 
 fn main() -> io::Result<()> {
+    //  debug
     // eprintln!("serf: pid {}", std::process::id());
     // if unsafe { libc::kill(std::process::id() as i32, libc::SIGSTOP) } != 0 {
     //     panic!("Could not stop ourselves.");

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -208,7 +208,7 @@ pub fn serf() -> io::Result<()> {
         None
     };
     if let Some(ref mut info) = trace_info.as_mut() {
-        if let Err(e) = write_metadata(info) {
+        if let Err(_e) = write_metadata(info) {
             //  XX: need NockStack allocated string interpolation
             // eprintln!("\rError initializing trace file: {:?}", e);
             trace_info = None;

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -209,7 +209,8 @@ pub fn serf() -> io::Result<()> {
     };
     if let Some(ref mut info) = trace_info.as_mut() {
         if let Err(e) = write_metadata(info) {
-            eprintln!("\rError initializing trace file: {:?}", e);
+            //  XX: need NockStack allocated string interpolation
+            // eprintln!("\rError initializing trace file: {:?}", e);
             trace_info = None;
         }
     }

--- a/rust/ares/src/snapshot/double_jam.rs
+++ b/rust/ares/src/snapshot/double_jam.rs
@@ -64,7 +64,8 @@ impl DoubleJam {
     fn load_snapshot(&self, stack: &mut NockStack, number: u8) -> io::Result<(u64, IndirectAtom)> {
         let path = self.path.join(format!("snapshot-{}.jam", number));
 
-        eprintln!("\rload: snapshot at {:?}", path);
+        //  XX: need NockStack allocated string interpolation
+        // eprintln!("\rload: snapshot at {:?}", path);
 
         let f = File::open(path)?;
 

--- a/rust/ares/src/snapshot/pma.rs
+++ b/rust/ares/src/snapshot/pma.rs
@@ -112,10 +112,12 @@ impl Snapshot for Pma {
     fn load(&mut self, _stack: &mut NockStack) -> std::io::Result<(u64, u64, Noun)> {
         let path = self.path.join(".bin/page.bin");
         if path.is_file() {
-            eprintln!("\rload: found snapshot at {:?}", path);
+            //  XX: need NockStack allocated string interpolation
+            // eprintln!("\rload: found snapshot at {:?}", path);
             unsafe { Ok(pma_load(&self.path)) }
         } else {
-            eprintln!("\rload: creating snapshot at {:?}", path);
+            //  XX: need NockStack allocated string interpolation
+            // eprintln!("\rload: creating snapshot at {:?}", path);
             unsafe { pma_init(&self.path) };
             Ok((0, 0, D(0)))
         }

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -99,7 +99,7 @@ pub fn write_metadata(info: &mut TraceInfo) -> Result<(), Error> {
 ///
 /// This should result in a well-formed partial trace file.
 pub fn write_serf_trace_safe(info: &mut Option<TraceInfo>, name: &str, start: Instant) {
-    if let Err(e) = write_serf_trace(info.as_mut().unwrap(), name, start) {
+    if let Err(_e) = write_serf_trace(info.as_mut().unwrap(), name, start) {
         //  XX: need NockStack allocated string interpolation
         // eprintln!("\rserf: error writing event trace to file: {:?}", e);
         *info = None;

--- a/rust/ares/src/trace.rs
+++ b/rust/ares/src/trace.rs
@@ -100,7 +100,8 @@ pub fn write_metadata(info: &mut TraceInfo) -> Result<(), Error> {
 /// This should result in a well-formed partial trace file.
 pub fn write_serf_trace_safe(info: &mut Option<TraceInfo>, name: &str, start: Instant) {
     if let Err(e) = write_serf_trace(info.as_mut().unwrap(), name, start) {
-        eprintln!("\rserf: error writing event trace to file: {:?}", e);
+        //  XX: need NockStack allocated string interpolation
+        // eprintln!("\rserf: error writing event trace to file: {:?}", e);
         *info = None;
     }
 }


### PR DESCRIPTION
Pending custom string interpolation logic which allocates on the `NockStack`, disable all print statements which perform string interpolation.

With these changes applied, `status` boots to dojo without needing to set `assert_no_alloc` to `warn` level in `Cargo.toml`.