### PR TITLE
virtualization: properly restore cold/warm states, cache, and scry stack when catching an error

### DIFF
--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -254,12 +254,6 @@ enum NockWork {
     Work12(Nock12),
 }
 
-pub struct SavedContext {
-    cold: Cold,
-    warm: Warm,
-    cache: Hamt<Noun>,
-}
-
 pub struct Context {
     pub stack: NockStack,
     // For printing slogs; if None, print to stdout; Option slated to be removed
@@ -272,22 +266,6 @@ pub struct Context {
     pub cache: Hamt<Noun>,
     pub scry_stack: Noun,
     pub trace_info: Option<TraceInfo>,
-}
-
-impl Context {
-    pub fn save(&self) -> SavedContext {
-        SavedContext {
-            cold: self.cold,
-            warm: self.warm,
-            cache: self.cache,
-        }
-    }
-
-    pub fn restore(&mut self, saved: SavedContext) {
-        self.cold = saved.cold;
-        self.warm = saved.warm;
-        self.cache = saved.cache;
-    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -254,6 +254,12 @@ enum NockWork {
     Work12(Nock12),
 }
 
+pub struct SavedContext {
+    cold: Cold,
+    warm: Warm,
+    cache: Hamt<Noun>,
+}
+
 pub struct Context {
     pub stack: NockStack,
     // For printing slogs; if None, print to stdout; Option slated to be removed
@@ -266,6 +272,22 @@ pub struct Context {
     pub cache: Hamt<Noun>,
     pub scry_stack: Noun,
     pub trace_info: Option<TraceInfo>,
+}
+
+impl Context {
+    pub fn save(&self) -> SavedContext {
+        SavedContext {
+            cold: self.cold,
+            warm: self.warm,
+            cache: self.cache,
+        }
+    }
+
+    pub fn restore(&mut self, saved: SavedContext) {
+        self.cold = saved.cold;
+        self.warm = saved.warm;
+        self.cache = saved.cache;
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/rust/ares/src/jets/cold.rs
+++ b/rust/ares/src/jets/cold.rs
@@ -267,6 +267,7 @@ impl Iterator for NounList {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct Cold(*mut ColdMem);
 
 struct ColdMem {

--- a/rust/ares/src/jets/nock.rs
+++ b/rust/ares/src/jets/nock.rs
@@ -74,9 +74,7 @@ pub mod util {
     use crate::interpreter::{interpret, Context, Error};
     use crate::jets;
     use crate::jets::bits::util::rip;
-    use crate::jets::cold::Cold;
     use crate::jets::form::util::scow;
-    use crate::jets::warm::Warm;
     use crate::mem::NockStack;
     use crate::noun::{tape, Cell, Noun, D, T};
     use ares_macros::tas;
@@ -85,27 +83,6 @@ pub mod util {
 
     pub const LEAF: Noun = D(tas!(b"leaf"));
     pub const ROSE: Noun = D(tas!(b"rose"));
-
-    pub struct ContextSnapshot {
-        pub cold: Cold,
-        pub warm: Warm,
-        pub cache: Hamt<Noun>,
-        pub scry_stack: Noun,
-    }
-
-    pub fn snapshot_and_virtualize(context: &mut Context, scry: Noun) -> ContextSnapshot {
-        let res = ContextSnapshot {
-            cold: context.cold,
-            warm: context.warm,
-            cache: context.cache,
-            scry_stack: context.scry_stack,
-        };
-
-        context.cache = Hamt::<Noun>::new();
-        context.scry_stack = T(&mut context.stack, &[scry, context.scry_stack]);
-
-        res
-    }
 
     /// The classic "slam gate" formula.
     pub fn slam_gate_fol(stack: &mut NockStack) -> Noun {

--- a/rust/ares/src/jets/warm.rs
+++ b/rust/ares/src/jets/warm.rs
@@ -7,6 +7,7 @@ use crate::noun::{Noun, Slots};
 use std::ptr::{copy_nonoverlapping, null_mut};
 
 /// key = formula
+#[derive(Copy, Clone)]
 pub struct Warm(Hamt<WarmEntry>);
 
 impl Preserve for Warm {

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -42,7 +42,7 @@ impl Context {
         // TODO: switch to Pma when ready
         // let snap = &mut snapshot::pma::Pma::new(snap_path);
         let mut snapshot = DoubleJam::new(snap_path);
-        let mut stack = NockStack::new(256 << 10 << 10, 0);
+        let mut stack = NockStack::new(512 << 10 << 10, 0);
 
         let cold = Cold::new(&mut stack);
         let hot = Hot::init(&mut stack);

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -321,6 +321,8 @@ fn goof(context: &mut Context, traces: Noun) -> Noun {
  *  Generate tracing events, if JSON tracing enabled.
  */
 fn soft(context: &mut Context, ovo: Noun, trace_name: Option<String>) -> Result<Noun, Noun> {
+    let cold_snapshot = context.nock_context.cold;
+    let warm_snapshot = context.nock_context.warm;
     let slam_res = if context.nock_context.trace_info.is_some() {
         let start = Instant::now();
         let slam_res = slam(context, POKE_AXIS, ovo);
@@ -339,6 +341,8 @@ fn soft(context: &mut Context, ovo: Noun, trace_name: Option<String>) -> Result<
         Ok(res) => Ok(res),
         Err(error) => match error {
             Error::Deterministic(trace) | Error::NonDeterministic(trace) => {
+                context.nock_context.cold = cold_snapshot;
+                context.nock_context.warm = warm_snapshot;
                 Err(goof(context, trace))
             }
             Error::ScryBlocked(_) | Error::ScryCrashed(_) => {


### PR DESCRIPTION
Fixed a bug caught by @ashelkovnykov 

@ashelkovnykov please confirm my understanding. In particular:

- [ ] `jet_mute` and `jet_mure` had the same bug as `mink`
- [ ] `jet_mute` and `jet_mure` additionally did not properly reset the scry stack in the context when catching an error.
- [ ] (not changed yet) `mink` further does not properly reset the scry stack in the context when catching an error