### PR TITLE
Pass in hot state

### DIFF
--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -19,7 +19,7 @@ use crate::jets::bits::*;
 use crate::jets::cold::Cold;
 use crate::jets::form::*;
 use crate::jets::hash::*;
-use crate::jets::hot::Hot;
+use crate::jets::hot::{Hot, URBIT_HOT_STATE};
 use crate::jets::list::*;
 use crate::jets::lute::*;
 use crate::jets::math::*;
@@ -281,7 +281,7 @@ pub mod util {
             let newt = Newt::new_mock();
             let cold = Cold::new(&mut stack);
             let warm = Warm::new();
-            let hot = Hot::init(&mut stack);
+            let hot = Hot::init(&mut stack, URBIT_HOT_STATE);
             let cache = Hamt::<Noun>::new();
 
             Context {

--- a/rust/ares/src/jets/hot.rs
+++ b/rust/ares/src/jets/hot.rs
@@ -4,7 +4,7 @@ use ares_macros::tas;
 use either::Either::{self, Left, Right};
 use std::ptr::null_mut;
 
-// const A_50: Either<u64, (u64, u64)> = Right((b"a", 50));
+// const A_50: Either<u8, (u64, u64)> = Right((tas!(b"a"), 50));
 const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
 
 // // This is the const state all in one spot as literals
@@ -57,8 +57,10 @@ const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
 //     (&[A_50, Left(b"mink")], 1, jet_mink),
 // ];
 
+pub type HotEntry = (&'static [Either<&'static [u8], (u64, u64)>], u64, Jet);
+
 #[allow(clippy::complexity)]
-const TRUE_HOT_STATE: &[(&[Either<&[u8], (u64, u64)>], u64, Jet)] = &[
+pub const URBIT_HOT_STATE: &'static [HotEntry] = &[
     (&[K_139, Left(b"one"), Left(b"add")], 1, jet_add),
     (&[K_139, Left(b"one"), Left(b"dec")], 1, jet_dec),
     (&[K_139, Left(b"one"), Left(b"div")], 1, jet_div),
@@ -595,10 +597,10 @@ const TRUE_HOT_STATE: &[(&[Either<&[u8], (u64, u64)>], u64, Jet)] = &[
 pub struct Hot(*mut HotMem);
 
 impl Hot {
-    pub fn init(stack: &mut NockStack) -> Self {
+    pub fn init(stack: &mut NockStack, constant_hot_state: &[HotEntry]) -> Self {
         unsafe {
             let mut next = Hot(null_mut());
-            for (htap, axe, jet) in TRUE_HOT_STATE {
+            for (htap, axe, jet) in constant_hot_state {
                 let mut a_path = D(0);
                 for i in *htap {
                     match i {

--- a/rust/ares/src/jets/hot.rs
+++ b/rust/ares/src/jets/hot.rs
@@ -4,8 +4,9 @@ use ares_macros::tas;
 use either::Either::{self, Left, Right};
 use std::ptr::null_mut;
 
-// const A_50: Either<u8, (u64, u64)> = Right((tas!(b"a"), 50));
-const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
+/** Root for Hoon %k.139
+ */
+pub const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
 
 // // This is the const state all in one spot as literals
 // #[allow(clippy::complexity)]
@@ -57,6 +58,10 @@ const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
 //     (&[A_50, Left(b"mink")], 1, jet_mink),
 // ];
 
+/** 
+ * (path, axis in battery, jet function pointer)
+ * see the [Jet] typedef in ares::jets for the proper prototype
+ */
 pub type HotEntry = (&'static [Either<&'static [u8], (u64, u64)>], u64, Jet);
 
 #[allow(clippy::complexity)]

--- a/rust/ares/src/jets/hot.rs
+++ b/rust/ares/src/jets/hot.rs
@@ -65,7 +65,7 @@ pub const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
 pub type HotEntry = (&'static [Either<&'static [u8], (u64, u64)>], u64, Jet);
 
 #[allow(clippy::complexity)]
-pub const URBIT_HOT_STATE: &'static [HotEntry] = &[
+pub const URBIT_HOT_STATE: &[HotEntry] = &[
     (&[K_139, Left(b"one"), Left(b"add")], 1, jet_add),
     (&[K_139, Left(b"one"), Left(b"dec")], 1, jet_dec),
     (&[K_139, Left(b"one"), Left(b"div")], 1, jet_div),

--- a/rust/ares/src/jets/hot.rs
+++ b/rust/ares/src/jets/hot.rs
@@ -58,7 +58,7 @@ pub const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
 //     (&[A_50, Left(b"mink")], 1, jet_mink),
 // ];
 
-/** 
+/**
  * (path, axis in battery, jet function pointer)
  * see the [Jet] typedef in ares::jets for the proper prototype
  */

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -1,3 +1,4 @@
+use ares::jets::hot::URBIT_HOT_STATE;
 use ares::serf::serf;
 use std::env;
 use std::io;
@@ -31,7 +32,7 @@ fn main() -> io::Result<()> {
     }
 
     if filename == "serf" {
-        return serf();
+        return serf(URBIT_HOT_STATE);
     }
 
     panic!("Ares can only run as a serf!");


### PR DESCRIPTION
Pass in the hot state as a parameter to `serf()`.

This enables distributing executables with other hot states by simply importing the ares crate, and passing in the additional hot state to the `serf()` call in the executable's `main()`.