### PR TITLE
build: support latest `urcrypt`

### DIFF
--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -29,7 +29,6 @@
               "rustfmt"
               "rust-src"
             ])
-            pkgs.autoconf-archive
             pkgs.cargo-watch
             pkgs.iconv
             pkgs.llvmPackages.clang

--- a/rust/nix/urcrypt.nix
+++ b/rust/nix/urcrypt.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkg-config, openssl, cryptopp, secp256k1, libaes_siv }:
-let rev = "375fa7e6a730d8aa517ca981b2b7b505bf4e1103";
+{ stdenv, fetchFromGitHub, autoreconfHook, autoconf-archive, pkg-config, openssl, cryptopp, secp256k1, libaes_siv }:
+let rev = "43479c3262a11e20da5f6218f3b0b3d63931ceea";
 in stdenv.mkDerivation {
   pname = "urcrypt";
   version = "git-${rev}";
@@ -7,14 +7,14 @@ in stdenv.mkDerivation {
     inherit rev;
     owner = "urbit";
     repo = "urcrypt";
-    hash = "sha256:1c3cqmwr5mys4v9y0834hxqfr6aynm2gav7730bjzfvrdc21ijqa";
+    hash = "sha256-GkhqvhDyhsdzjWpR8uqmhdRdhxdpmLGWXtIUZPAbWZs=";
   };
 
-  preConfigure = ''
-    ./autogen.sh
-    '';
+  # preConfigure = ''
+  #   ./autogen.sh
+  #   '';
 
-  nativeBuildInputs = [autoreconfHook pkg-config];
+  nativeBuildInputs = [autoreconfHook autoconf-archive pkg-config];
 
   buildInputs = [openssl cryptopp secp256k1 libaes_siv];
 }


### PR DESCRIPTION
Includes `autoconf-archive` in the `urcrypt.nix` file to support extra macros.