### PR TITLE
Implement fastpath for `jet_rev` where `boz = 0` and `boz = 3`

### DIFF
--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -57,3 +57,10 @@ check_forwarding = []
 check_junior = []
 sham_hints = []
 stop_for_debug = []
+
+[dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }
+
+[[bench]]
+name = "boz"
+harness = false

--- a/rust/ares/benches/boz.rs
+++ b/rust/ares/benches/boz.rs
@@ -1,0 +1,18 @@
+use ares::jets::bits::jet_rev;
+use ares::jets::util::test::init_context;
+use ares::noun::{D, T};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let ctx = &mut init_context();
+    let test = 0x1234567890123u64;
+    let sam = T(&mut ctx.stack, &[D(3), D(7), D(test)]);
+    c.bench_function("boz 3", |b| b.iter(|| jet_rev(ctx, sam)));
+
+    let a24 = D(0x876543);
+    let sam = T(&mut ctx.stack, &[D(0), D(60), a24]);
+    c.bench_function("boz 0", |b| b.iter(|| jet_rev(ctx, sam)));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
```
Running benches/boz.rs (target/release/deps/boz-c09d868d611fc8e8)
boz 3                   time:   [20.110 ns 20.178 ns 20.282 ns]
                        change: [-3.3792% -3.1311% -2.8160%] (p = 0.00 < 0.05)
                        Performance has improved.
```