### PR TITLE
remove cargo-watch for darwin-x86 because it doesn't build

### DIFF
--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -29,14 +29,15 @@
               "rustfmt"
               "rust-src"
             ])
-            pkgs.cargo-watch
             pkgs.bacon
             pkgs.iconv
             pkgs.llvmPackages.clang
             pkgs.pkg-config
             pkgs.urcrypt
           ] ++
-            (nixpkgs.lib.lists.optional (parsedSystem.kernel.name != "darwin") pkgs.gdb); # nixpkgs won't build gdb for darwin
+            (nixpkgs.lib.lists.optional (parsedSystem.kernel.name != "darwin") pkgs.gdb) # nixpkgs won't build gdb for darwin
+            ++
+            (nixpkgs.lib.lists.optional (parsedSystem.kernel.name != "darwin") pkgs.cargo-watch); # nixpkgs won't build gdb for darwin
         };
       }
     );

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -37,7 +37,7 @@
           ] ++
             (nixpkgs.lib.lists.optional (parsedSystem.kernel.name != "darwin") pkgs.gdb) # nixpkgs won't build gdb for darwin
             ++
-            (nixpkgs.lib.lists.optional (parsedSystem.kernel.name != "darwin") pkgs.cargo-watch); # nixpkgs won't build gdb for darwin
+            (nixpkgs.lib.lists.optional (parsedSystem.kernel.name != "darwin" || parsedSystem.cpu.name != "x86_64") pkgs.cargo-watch); # nixpkgs won't build cargo-watch for darwin-x86
         };
       }
     );


### PR DESCRIPTION
The mac x86 build fails because the cargo-watch build fails with some weird build error inside the quartz framework headers. This fixes the build by excluding cargo-watch.

