### PR TITLE
pma: clear pending_flist after completion of _pending_flist_merge

### DIFF
--- a/rust/ares_pma/c-src/btree.c
+++ b/rust/ares_pma/c-src/btree.c
@@ -1134,6 +1134,7 @@ _pending_flist_merge(BT_state *state)
     src_head = src_head->next;
     free(prev);
   }
+  state->pending_flist = 0;
 }
 
 


### PR DESCRIPTION
use-after-free was responsible for crash