### PR TITLE
interpreter: check for copying flag in exit

### DIFF
--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -1185,6 +1185,11 @@ fn exit(
     unsafe {
         context.restore(snapshot);
 
+        if context.stack.copying() {
+            assert!(context.stack.get_frame_pointer() != virtual_frame);
+            context.stack.frame_pop();
+        }
+
         let stack = &mut context.stack;
         let mut preserve = match error {
             Error::ScryBlocked(path) => path,
@@ -1192,6 +1197,7 @@ fn exit(
                 // Return $tang of traces
                 let h = *(stack.local_noun_pointer(0));
                 // XX: Small chance of clobbering something important after OOM?
+                // XX: what if we OOM while making a stack trace
                 T(stack, &[h, t])
             }
         };

--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -137,6 +137,10 @@ impl NockStack {
         };
     }
 
+    pub fn copying(&self) -> bool {
+        self.pc
+    }
+
     /** Current frame pointer of this NockStack */
     pub fn get_frame_pointer(&self) -> *const u64 {
         self.frame_pointer


### PR DESCRIPTION
An OOM nondeterministic error can cause exit() to begin with a frame in copying mode. This causes an assertion failure when we allocate a cell for the stack trace. 

This PR does not yet handle recursive OOMing (i.e. OOMing when we are making a stack trace) which should be handled, but it does handle the case of OOMing during a `preserve()`.