### PR TITLE
pma: fix regression on restore

### DIFF
--- a/rust/ares_pma/c-src/btest.c
+++ b/rust/ares_pma/c-src/btest.c
@@ -157,30 +157,6 @@ int main(int argc, char *argv[])
   BT_findpath path = {0};
   int rc = 0;
 
-  /* broken with recent changes. Maybe because we aren't mmapping the data
-     ranges (pure _bt_insert) */
-#if 0
-
-  DPUTS("== test 1: insert");
-
-  bt_state_new(&state1);
-  if (mkdir("./pmatest1", 0774) == -1)
-    return errno;
-  assert(SUCC(bt_state_open(state1, "./pmatest1", 0, 0644)));
-
-#define LOWEST_ADDR 0x2aaa80;
-  vaof_t lo = LOWEST_ADDR;
-  vaof_t hi = 0xDEADBEEF;
-  pgno_t pg = 1;                /* dummy value */
-  for (size_t i = 0; i < BT_DAT_MAXKEYS * 4; ++i) {
-    _bt_insert(state1, lo, hi, pg);
-    _test_nodeinteg(state1, &path, lo, hi, pg);
-    lo++; pg++;
-  }
-
-  bt_state_close(state1);
-#endif
-
 
   DPUTS("== test 2: malloc");
   BT_state *state2;
@@ -340,7 +316,7 @@ int main(int argc, char *argv[])
   assert(SUCC(bt_state_open(state4, "./pmatest4", 0, 0644)));
 
   assert(state4->file_size_p == PMA_INITIAL_SIZE_p + PMA_GROW_SIZE_p * 2);
-  assert(state4->flist->hi == state4->file_size_p);
+  assert(state4->flist->next->hi == state4->file_size_p);
 
 
   DPUTS("== test 5: partition striping");

--- a/rust/ares_pma/c-src/btest.c
+++ b/rust/ares_pma/c-src/btest.c
@@ -299,6 +299,7 @@ int main(int argc, char *argv[])
 
 #define PMA_INITIAL_SIZE_p PMA_GROW_SIZE_p
   BYTE *t4a = bt_malloc(state4, PMA_GROW_SIZE_p * 2);
+  BYTE *t4a_copy = malloc(PMA_GROW_SIZE_b * 2);
   BYTE *t4b = t4a;
   for (size_t i = 0; i < PMA_GROW_SIZE_b * 2; i++) {
     *t4b++ = rand();
@@ -309,6 +310,7 @@ int main(int argc, char *argv[])
      tail. The hi page here should match the file size */
   assert(state4->flist->hi == state4->file_size_p);
 
+  memcpy(t4a_copy, t4a, PMA_GROW_SIZE_b * 2);
   bt_state_close(state4);
 
   bt_state_new(&state4);
@@ -317,6 +319,17 @@ int main(int argc, char *argv[])
 
   assert(state4->file_size_p == PMA_INITIAL_SIZE_p + PMA_GROW_SIZE_p * 2);
   assert(state4->flist->next->hi == state4->file_size_p);
+
+  for (size_t i = 0; i < PMA_GROW_SIZE_b * 2; i++)
+    assert(t4a_copy[i] == t4a[i]);
+
+  void *t4c = bt_malloc(state4, 10);
+  bt_sync(state4);
+  void *t4d = bt_malloc(state4, 10);
+  bt_sync(state4);
+  void *t4e = bt_malloc(state4, 10);
+  bt_sync(state4);
+
 
 
   DPUTS("== test 5: partition striping");

--- a/rust/ares_pma/c-src/btree.c
+++ b/rust/ares_pma/c-src/btree.c
@@ -1516,7 +1516,7 @@ _bt_insert2(BT_state *state, vaof_t lo, vaof_t hi, pgno_t fo,
   /* nullcond: node is a leaf */
   if (meta->depth == depth) {
     /* dirty the data range */
-    _bt_dirtydata(node, childidx); /* ;;: I believe this is incorrect. We should just directly modify the dirty bitset in _bt_insertdat */
+    _bt_dirtydata(node, childidx);
     /* guaranteed non-full and dirty by n-1 recursive call, so just insert */
     return _bt_insertdat(lo, hi, fo, node, childidx);
   }
@@ -2212,7 +2212,7 @@ _bt_state_restore_maps(BT_state *state)
 
 static int
 _bt_state_meta_which(BT_state *state)
-{                               /* ;;: TODO you need to mprotect writable the current metapage */
+{
   BT_meta *m1 = state->meta_pages[0];
   BT_meta *m2 = state->meta_pages[1];
   int which = -1;
@@ -2513,7 +2513,7 @@ _bt_state_load(BT_state *state)
   }
 
   /* map the node segment */
-  _bt_state_map_node_segment(state); /* ;;: this should follow a call to  _bt_state_meta_new. hmm... but that leads to a bad dependency graph. We may need to separately initialize the first partition and only call map_node_segment on restore. */
+  _bt_state_map_node_segment(state);
 
   /* new db, so populate metadata */
   if (new) {
@@ -2736,7 +2736,7 @@ _bt_sync(BT_state *state, BT_page *node, uint8_t depth, uint8_t maxdepth)
 
   /* do dfs */
   for (size_t i = 0; i < N-1; i++) {
-    if (!_bt_ischilddirty(node, i)) /* ;;: consider removing case until dirty logic is foolproof */
+    if (!_bt_ischilddirty(node, i))
       continue;                 /* not dirty. nothing to do */
 
     BT_page *child = _node_get(state, node->datk[i].fo);

--- a/rust/ares_pma/c-src/btree.c
+++ b/rust/ares_pma/c-src/btree.c
@@ -2311,7 +2311,7 @@ _bt_state_read_header(BT_state *state)
 static int
 _bt_state_meta_new(BT_state *state)
 {
-  BT_page *p1, *p2;
+  BT_page *p1;
   BT_meta meta = {0};
 
   TRACE();
@@ -2335,14 +2335,11 @@ _bt_state_meta_new(BT_state *state)
   meta.depth = 1;
   meta.flags = BP_META;
 
-  /* initialize the metapages */
+  /* initialize the first metapage */
   p1 = &((BT_page *)state->map)[0];
-  p2 = &((BT_page *)state->map)[1];
 
   /* copy the metadata into the metapages */
   memcpy(METADATA(p1), &meta, sizeof meta);
-  /* ;;: writing to the second metapage really isn't necessary and it's probably better to leave it zeroed */
-  /* memcpy(METADATA(p2), &meta, sizeof meta); */
 
   /* only the active metapage should be writable (first page) */
   if (mprotect(BT_MAPADDR, BT_META_SECTION_WIDTH, BT_PROT_CLEAN) != 0) {


### PR DESCRIPTION
There was a regression introduced with partition striping that caused problems on restore due to node partitions incidentally getting mapped anonymous rather than to the backing file