### PR TITLE
bump hoon root to %k.138

### DIFF
--- a/rust/ares/src/jets/hot.rs
+++ b/rust/ares/src/jets/hot.rs
@@ -4,9 +4,9 @@ use ares_macros::tas;
 use either::Either::{self, Left, Right};
 use std::ptr::{copy_nonoverlapping, null_mut};
 
-/** Root for Hoon %k.139
+/** Root for Hoon %k.138
  */
-pub const K_139: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 139));
+pub const K_138: Either<&[u8], (u64, u64)> = Right((tas!(b"k"), 138));
 
 // // This is the const state all in one spot as literals
 // #[allow(clippy::complexity)]
@@ -66,163 +66,163 @@ pub type HotEntry = (&'static [Either<&'static [u8], (u64, u64)>], u64, Jet);
 
 #[allow(clippy::complexity)]
 pub const URBIT_HOT_STATE: &[HotEntry] = &[
-    (&[K_139, Left(b"one"), Left(b"add")], 1, jet_add),
-    (&[K_139, Left(b"one"), Left(b"dec")], 1, jet_dec),
-    (&[K_139, Left(b"one"), Left(b"div")], 1, jet_div),
-    (&[K_139, Left(b"one"), Left(b"dvr")], 1, jet_dvr),
-    (&[K_139, Left(b"one"), Left(b"gte")], 1, jet_gte),
-    (&[K_139, Left(b"one"), Left(b"gth")], 1, jet_gth),
-    (&[K_139, Left(b"one"), Left(b"lte")], 1, jet_lte),
-    (&[K_139, Left(b"one"), Left(b"lth")], 1, jet_lth),
-    (&[K_139, Left(b"one"), Left(b"max")], 1, jet_max),
-    (&[K_139, Left(b"one"), Left(b"min")], 1, jet_min),
-    (&[K_139, Left(b"one"), Left(b"mod")], 1, jet_mod),
-    (&[K_139, Left(b"one"), Left(b"mul")], 1, jet_mul),
-    (&[K_139, Left(b"one"), Left(b"sub")], 1, jet_sub),
+    (&[K_138, Left(b"one"), Left(b"add")], 1, jet_add),
+    (&[K_138, Left(b"one"), Left(b"dec")], 1, jet_dec),
+    (&[K_138, Left(b"one"), Left(b"div")], 1, jet_div),
+    (&[K_138, Left(b"one"), Left(b"dvr")], 1, jet_dvr),
+    (&[K_138, Left(b"one"), Left(b"gte")], 1, jet_gte),
+    (&[K_138, Left(b"one"), Left(b"gth")], 1, jet_gth),
+    (&[K_138, Left(b"one"), Left(b"lte")], 1, jet_lte),
+    (&[K_138, Left(b"one"), Left(b"lth")], 1, jet_lth),
+    (&[K_138, Left(b"one"), Left(b"max")], 1, jet_max),
+    (&[K_138, Left(b"one"), Left(b"min")], 1, jet_min),
+    (&[K_138, Left(b"one"), Left(b"mod")], 1, jet_mod),
+    (&[K_138, Left(b"one"), Left(b"mul")], 1, jet_mul),
+    (&[K_138, Left(b"one"), Left(b"sub")], 1, jet_sub),
     //
-    (&[K_139, Left(b"one"), Left(b"cap")], 1, jet_cap),
-    (&[K_139, Left(b"one"), Left(b"mas")], 1, jet_mas),
-    (&[K_139, Left(b"one"), Left(b"peg")], 1, jet_peg),
+    (&[K_138, Left(b"one"), Left(b"cap")], 1, jet_cap),
+    (&[K_138, Left(b"one"), Left(b"mas")], 1, jet_mas),
+    (&[K_138, Left(b"one"), Left(b"peg")], 1, jet_peg),
     //
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"flop")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"flop")],
         1,
         jet_flop,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"lent")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"lent")],
         1,
         jet_lent,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"turn")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"turn")],
         1,
         jet_turn,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"zing")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"zing")],
         1,
         jet_zing,
     ),
     //
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"bex")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"bex")],
         1,
         jet_bex,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"can")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"can")],
         1,
         jet_can,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"cat")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"cat")],
         1,
         jet_cat,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"cut")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"cut")],
         1,
         jet_cut,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"end")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"end")],
         1,
         jet_end,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"lsh")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"lsh")],
         1,
         jet_lsh,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"met")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"met")],
         1,
         jet_met,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"rap")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"rap")],
         1,
         jet_rap,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"rep")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"rep")],
         1,
         jet_rep,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"rev")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"rev")],
         1,
         jet_rev,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"rip")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"rip")],
         1,
         jet_rip,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"rsh")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"rsh")],
         1,
         jet_rsh,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"xeb")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"xeb")],
         1,
         jet_xeb,
     ),
     //
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"con")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"con")],
         1,
         jet_con,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"dis")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"dis")],
         1,
         jet_dis,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"mix")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"mix")],
         1,
         jet_mix,
     ),
     //
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"mug")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"mug")],
         1,
         jet_mug,
     ),
     //
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"dor")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"dor")],
         1,
         jet_dor,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"gor")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"gor")],
         1,
         jet_gor,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"mor")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"mor")],
         1,
         jet_mor,
     ),
     //
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"cue")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"cue")],
         1,
         jet_cue,
     ),
     (
-        &[K_139, Left(b"one"), Left(b"two"), Left(b"jam")],
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"jam")],
         1,
         jet_jam,
     ),
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -234,7 +234,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -246,7 +246,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -258,7 +258,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -270,7 +270,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -283,7 +283,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -296,7 +296,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -310,7 +310,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -324,7 +324,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -338,7 +338,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -351,7 +351,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -364,7 +364,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -377,7 +377,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -390,7 +390,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -404,7 +404,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -418,7 +418,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -432,7 +432,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -446,7 +446,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -460,7 +460,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -474,7 +474,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -488,7 +488,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -502,7 +502,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -516,7 +516,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -530,7 +530,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -543,7 +543,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -555,7 +555,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -567,7 +567,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -580,7 +580,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -594,7 +594,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -608,7 +608,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -622,7 +622,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -636,7 +636,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -650,7 +650,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -666,7 +666,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     ),
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -681,7 +681,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -698,7 +698,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -715,7 +715,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -732,7 +732,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -749,7 +749,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -766,7 +766,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -783,7 +783,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -800,7 +800,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -817,7 +817,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),
@@ -834,7 +834,7 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
     //
     (
         &[
-            K_139,
+            K_138,
             Left(b"one"),
             Left(b"two"),
             Left(b"tri"),


### PR DESCRIPTION
Not sure if there was a particular reason this hadn't been updated, or if nobody had gotten around to doing it yet.

I've confirmed that Nockchain runs fine with this. However, `test_sivb_en` fails. It currently passes on the `status` branch.

``` 
test jets::lock::aes::tests::test_siva_de ... ok
test jets::lock::aes::tests::test_siva_en ... ok
test jets::lock::aes::tests::test_sivb_de ... ok
memory allocation of test jets::lock::aes::tests::test_sivb_en ... 24ok bytes failed
```

I spent a few minutes looking into this but nothing popped out at me.